### PR TITLE
Refactor periodic regen ci req

### DIFF
--- a/.github/workflows/regen-ci-req-check.yml
+++ b/.github/workflows/regen-ci-req-check.yml
@@ -28,7 +28,9 @@ jobs:
         if: steps.regen_ci_reqs.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a repository-scoped Personal Access Token (PAT) stored in secrets.REGEN_PR_TOKEN.
+          # This ensures the PR creation event is not suppressed by GitHub and will trigger downstream workflows.
+          token: ${{ secrets.REGEN_PR_TOKEN }}
           title: "[auto] regen pinned requirements"
           commit-message: "Auto-regenerate pinned requirements via scheduled regen-check"
           branch: regen/pinned-requirements-${{ github.run_id }}

--- a/.github/workflows/regen-ci-req-check.yml
+++ b/.github/workflows/regen-ci-req-check.yml
@@ -22,7 +22,7 @@ jobs:
           python_version: '3.12'
           ci_output_dir: requirements/ci
           compare_paths: "requirements/ci/requirements.txt requirements/post_upgrades.txt requirements/platform_dependent.txt"
-          patch_path: regen_diff.patch
+          patch_path: /tmp/regen_diff.patch
 
       - name: Create PR with updated pins
         if: steps.regen_ci_reqs.outputs.changed == 'true'

--- a/.github/workflows/regen-ci-req-report.yml
+++ b/.github/workflows/regen-ci-req-report.yml
@@ -63,19 +63,19 @@ jobs:
           python_version: '3.12'
           ci_output_dir: requirements/ci
           compare_paths: "requirements/ci/requirements.txt requirements/post_upgrades.txt requirements/platform_dependent.txt"
-          patch_path: regen_diff.patch
+          patch_path: /tmp/regen_diff.patch
 
       - name: Upload regen diff (if present)
         if: steps.regen_ci_reqs.outputs.changed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: regen-pins-diff
-          path: regen_diff.patch
+          path: /tmp/regen_diff.patch
 
       - name: Compute top-5 package-change summary
         if: steps.regen_ci_reqs.outputs.changed == 'true'
         run: |
-          python scripts/regen_summary.py regen_diff.patch regen_summary.txt
+          python scripts/regen_summary.py /tmp/regen_diff.patch regen_summary.txt
 
 
       - name: Create or update PR comment (single-comment)


### PR DESCRIPTION
use PAT for periodic regen ci req PR to avoid recursive checks associated with default token and update path to regen_diff.patch artifact