### PR TITLE
Introduce ITClassMetadata and repr_helpers, improve determinism flexibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,134 @@ Contact
 - If you're unsure whether an import should be deferred, or how to centralize it safely, open an issue or a draft PR and tag a maintainer for guidance.
 
 Thanks for helping keep Interpretune fast and maintainable!
+
+## Object summary helpers for __repr__
+
+Motivation
+- We want compact, safe, and informative `__repr__` output for important Interpretune objects (for example `ITState`, modules, and sessions) without accidentally materializing large objects (tensors, datasets, large configuration classes) or invoking heavy initialization. A small centralized helper ensures a consistent policy and reduces duplication.
+
+Where to look
+- The centralized helpers live in `src/interpretune/utils/repr_helpers.py`.
+
+What it provides
+- `summarize_obj(obj)` — a small, non‑materializing summary for common value types (tensors summarized by shape/dtype/device, dicts by keys/length, lists/tuples/sets by length, strings truncated). Custom objects are rendered as `ClassName(...)` to indicate a stateful object.
+- `state_to_dict(obj, custom_key_transforms=...)` — reads `obj._obj_summ_map` (a dict mapping attribute name -> label) and returns a JSON‑serializable dict of summaries. This is the canonical way to build a safe inspectable dict for an object.
+- `state_to_summary(state_dict, obj)` — builds a compact parenthesized single‑line summary using the ordering and labels defined in `obj._obj_summ_map`.
+- `state_repr(summary, class_name)` — formats the final `ClassName(...)` string given the parenthesized summary.
+
+How to use it (recommended)
+1. Define a per‑class `_obj_summ_map` dictionary mapping attribute names to labels. Keep keys as actual attribute names and labels as the human‑facing name to display in summaries. Example:
+
+```python
+_obj_summ_map = {
+  "_device": "device",
+  "_current_epoch": "epoch",
+  "_global_step": "step",
+  "_init_hparams": "init_cfg",
+}
+```
+
+2. Use `state_to_dict(self, custom_key_transforms={...})` in your `to_dict()` implementation. Provide `custom_key_transforms` for keys that need bespoke handling (for example, summarizing nested dicts or representing extension state):
+
+```python
+def to_dict(self):
+  return state_to_dict(self, custom_key_transforms={"_init_hparams": self._init_hparams_transform})
+```
+
+3. In `__repr__()`, build the compact summary via `state_to_summary(d, self)` and format with `state_repr(...)`:
+
+```python
+# in __repr__()
+inner = state_to_summary(self.to_dict(), self)
+return state_repr(inner, self.__class__.__name__)
+```
+
+Custom transforms
+- `state_to_dict` supports a `custom_key_transforms` mapping from attribute name (the dict key in `_obj_summ_map`) to a callable that takes the raw attribute value and returns a safe serializable summary. Typical use cases:
+  - Truncate long strings
+  - Represent nested dictionaries as `"{...}"` to avoid printing huge nested content
+  - Represent custom config objects with a short string like `MyCfg(...)`
+
+Example transform:
+
+```python
+# Custom transform for summarizing the `_init_hparams` mapping in ITState
+@staticmethod
+def _init_hparams_transform(v):
+  if not v:
+    return {}
+  out = {}
+  for k, val in v.items():
+    if isinstance(val, dict):
+      out[k] = "{...}" if val else {}
+    else:
+      out[k] = summarize_obj(val)
+  return out
+```
+
+Notes
+- Keep the transforms cheap and side‑effect free. Never call into expensive setup code or materialize tensors — prefer `summarize_obj` for safety.
+- This mechanism is intentionally conservative: it is meant for developer‑facing summaries and debugging, not for full serialization of state.
+
+## Interpretune Core Class-level Internal Metadata (`_it_cls_metadata`)
+
+To maximize compositional flexibility while reducing noise when inspecting/debugging core Interpretune classes, we make the set of internal, implementation-focused class attributes explicit and consolidate related class-level constants into a single protected container named `_it_cls_metadata` on core classes (for example `ITSession`, `PropertyDispatcher` implementations, and adapter classes).
+
+The container is a typed, frozen dataclass (`ITClassMetadata`) held as a protected class attribute. It centralizes values like attribute-mapping tables, composition target names, and small tuples of internal method names.
+
+### Utility and benefits
+- Cleaner debugging: developers inspecting a class see a single protected attribute instead of many scattered constants.
+- Safer extension: the dataclass is frozen to discourage accidental reassignment, while nested mutable containers (dicts) may be mutated in-place by adapters or tests when needed.
+- Better discoverability: tooling and docs can point to a single symbol to explain how to customize class-level behavior.
+
+### How to use
+- The container is intended to be overridden on subclasses when custom behavior is required. Prefer replacing the entire `_it_cls_metadata` with a new `ITClassMetadata` instance in subclass definitions rather than mutating at import time from unrelated modules.
+
+Example:
+
+```py
+from interpretune.base.metadata import ITClassMetadata
+from interpretune.protocol import Adapter
+
+# Define the adapter and its metadata directly, following the same
+# pattern used by built-in adapters (for example `LightningAdapter`).
+class MyFrameworkAdapter:
+  _it_cls_metadata = ITClassMetadata(
+    core_to_framework_attrs_map={
+      # Map internal core names to framework attribute paths/defaults/messages
+      "_it_optimizers": ("trainer.optimizers", None, "No optimizers have been set yet."),
+      "_current_epoch": ("trainer.current_epoch", 0, "No epoch available"),
+      # Add framework-specific helpers or custom mappings here
+      "_custom_hook": ("trainer.custom_hook", None, "Custom hook not registered"),
+    },
+    property_composition={
+      # Example: expose a `device` property that dispatches to a framework mixin
+      "device": {"enabled": True, "target": object, "dispatch": lambda self: "device"},
+    },
+  )
+
+  @classmethod
+  def register_adapter_ctx(cls, adapter_ctx_registry):
+    adapter_ctx_registry.register(
+      Adapter.some_framework,
+      component_key="module",
+      adapter_combination=(Adapter.some_framework,),
+      composition_classes=(MyFrameworkAdapter,),
+      description="Adapter for SomeFramework",
+    )
+
+  # Instances of classes composed with MyFrameworkAdapter will see the
+  # adapter-supplied mappings via `type(obj)._it_cls_metadata.core_to_framework_attrs_map`.
+```
+
+Note: when customizing an existing base adapter (instead of defining a new
+adapter from scratch), prefer using `dataclasses.replace()` on the base
+adapter's `_it_cls_metadata` to preserve unrelated fields on the frozen
+dataclass. Constructing metadata directly (as shown above) is the common
+pattern for adding new adapters; customizing an existing adapter is a
+secondary workflow and `replace()` makes it safe and explicit.
+
+Notes and recommendations
+- Prefer overriding `_it_cls_metadata` at the class definition site. This makes the intent explicit and avoids cross-module side effects.
+- If you must patch behavior in tests, mutate nested containers (for example `type(obj)._it_cls_metadata.core_to_framework_attrs_map[...] = ...`) rather than replacing the dataclass instance — the latter is permitted but can make test isolation harder if not reverted.
+- Document any non-obvious overrides in your module's docstring so users can easily understand the intent.

--- a/src/interpretune/adapters/lightning.py
+++ b/src/interpretune/adapters/lightning.py
@@ -9,28 +9,33 @@ if _LIGHTNING_AVAILABLE:
     from lightning.pytorch import LightningDataModule, LightningModule
 
     class LightningAdapter:
-        CORE_TO_FRAMEWORK_ATTRS_MAP = {
-            "_it_lr_scheduler_configs": (
-                "trainer.strategy.lr_scheduler_configs",
-                None,
-                "No lr_scheduler_configs have been set.",
-            ),
-            "_it_optimizers": ("trainer.optimizers", None, "No optimizers have been set yet."),
-            "_log_dir": ("trainer.model._trainer.log_dir", None, "No log_dir has been set yet."),
-            "_datamodule": (
-                "trainer.datamodule",
-                None,
-                "Could not find datamodule reference (has it been attached yet?)",
-            ),
-            "_current_epoch": ("trainer.current_epoch", 0, ""),
-            "_global_step": ("trainer.global_step", 0, ""),
-        }
+        from interpretune.base.metadata import ITClassMetadata  # local import to avoid cycles
 
-        PROPERTY_COMPOSITION = {
-            # property composition is by default only enabled for `device` if Lightning is available and only effective
-            # if Lightning actively being used.
-            "device": {"enabled": True, "target": _DeviceDtypeModuleMixin, "dispatch": _DeviceDtypeModuleMixin.device}
-        }
+        _it_cls_metadata = ITClassMetadata(
+            core_to_framework_attrs_map={
+                "_it_lr_scheduler_configs": (
+                    "trainer.strategy.lr_scheduler_configs",
+                    None,
+                    "No lr_scheduler_configs have been set.",
+                ),
+                "_it_optimizers": ("trainer.optimizers", None, "No optimizers have been set yet."),
+                "_log_dir": ("trainer.model._trainer.log_dir", None, "No log_dir has been set yet."),
+                "_datamodule": (
+                    "trainer.datamodule",
+                    None,
+                    "Could not find datamodule reference (has it been attached yet?)",
+                ),
+                "_current_epoch": ("trainer.current_epoch", 0, ""),
+                "_global_step": ("trainer.global_step", 0, ""),
+            },
+            property_composition={
+                "device": {
+                    "enabled": True,
+                    "target": _DeviceDtypeModuleMixin,
+                    "dispatch": _DeviceDtypeModuleMixin.device,
+                }
+            },
+        )
 
         def on_train_start(self) -> None:
             # ensure model is in training mode (e.g. needed for some edge cases w/ skipped sanity checking)

--- a/src/interpretune/base/components/mixins.py
+++ b/src/interpretune/base/components/mixins.py
@@ -148,7 +148,10 @@ class GenerativeStepMixin:
     # Often used for n-shot classification, those contexts are only a subset of generative classification use cases
 
     _gen_sig_keys: list | None = None
-    GEN_PREPARES_INPUTS_SIGS: tuple = ("_prepare_model_inputs",)
+    # class-level metadata container to reduce attribute clutter
+    from interpretune.base.metadata import ITClassMetadata  # local import to avoid top-level cycle
+
+    _it_cls_metadata = ITClassMetadata(gen_prepares_inputs_sigs=("_prepare_model_inputs",))
 
     @property
     def generation_cfg(self) -> BaseGenerationConfig | None:
@@ -183,7 +186,8 @@ class GenerativeStepMixin:
 
     def _generate_prepares_inputs(self) -> bool:
         # match sentinal methods indicating that a given model's generate function prepares inputs
-        return any(hasattr(self.model, prep_method) for prep_method in self.GEN_PREPARES_INPUTS_SIGS)  # type: ignore[attr-defined]  # mixin provides model
+        sigs = type(self)._it_cls_metadata.gen_prepares_inputs_sigs
+        return any(hasattr(self.model, prep_method) for prep_method in sigs)  # type: ignore[attr-defined]  # mixin provides model
 
     def it_generate(self, batch: BatchEncoding | torch.Tensor, **kwargs) -> Any:
         try:

--- a/src/interpretune/base/metadata.py
+++ b/src/interpretune/base/metadata.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple, Type
+
+
+@dataclass(frozen=True)
+class ITClassMetadata:
+    """Structured, typed container for class-level Interpretune metadata.
+
+    Use instances of this dataclass as a single protected class attribute
+    (e.g. `_it_cls_metadata`) to reduce attribute clutter on public classes.
+    """
+
+    base_attrs: Dict[Any, Tuple[str, ...]] = field(default_factory=dict)
+    ready_attrs: Tuple[str, ...] = field(default_factory=tuple)
+    composition_target_attrs: Tuple[str, ...] = field(default_factory=tuple)
+    ready_protocols: Tuple[Type, ...] = field(default_factory=tuple)
+
+    # Generic extension points used by other components
+    core_to_framework_attrs_map: Dict[str, Any] = field(default_factory=dict)
+    property_composition: Dict[str, Any] = field(default_factory=dict)
+    gen_prepares_inputs_sigs: Tuple[str, ...] = field(default_factory=tuple)

--- a/src/interpretune/base/modules.py
+++ b/src/interpretune/base/modules.py
@@ -55,3 +55,13 @@ class BaseITModule(BaseITMixins, BaseITComponents, BaseITHooks, torch.nn.Module)
         if getattr(self, "memprofiler", None):
             self.memprofiler.dump_memory_stats()
         self._it_state._session_complete = True
+
+    def __repr__(self) -> str:
+        try:
+            state_summary = getattr(self, "_it_state", None)
+            state_str = repr(state_summary) if state_summary is not None else "ITState(<no state>)"
+            model_name = getattr(self.model, "__class__", None)
+            model_repr = model_name.__name__ if model_name is not None else str(self.model)
+            return f"{self.__class__.__name__}({state_str}, model={model_repr})"
+        except Exception:
+            return super().__repr__()

--- a/src/interpretune/utils/repr_helpers.py
+++ b/src/interpretune/utils/repr_helpers.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Callable
+import torch
+import os
+# Note: callers should provide an `_obj_summ_map` dict mapping attribute_name -> label
+
+
+def summarize_tensor(t: torch.Tensor) -> str:
+    return f"Tensor(shape={tuple(t.shape)}, dtype={getattr(t, 'dtype', None)}, device={getattr(t, 'device', None)})"
+
+
+def summarize_primitive(obj: Any, max_len: int = 20) -> str:
+    s = repr(obj)
+    if len(s) > max_len:
+        return s[: max_len - 3] + "..."
+    return s
+
+
+def summarize_container(obj: Any) -> str:
+    try:
+        return f"{obj.__class__.__name__}(len={len(obj)})"
+    except Exception:
+        return obj.__class__.__name__
+
+
+def summarize_dict_keys(d: Dict, max_keys: int = 8) -> Dict:
+    keys = list(d.keys())
+    return {"len": len(keys), "keys": keys[:max_keys]}
+
+
+def summarize_obj(obj: Any) -> Any:
+    """Return a JSON-serializable small summary for `obj`.
+
+    Rules:
+    - torch.Tensor -> shape/dtype/device string
+    - dict -> {len:int, keys:[...first keys...]}
+    - list/tuple/set -> ClassName(len=N)
+    - str -> truncated primitive
+    - path-like (os.PathLike / pathlib.Path) -> string path
+    - objects with __class__ -> class name
+    """
+    try:
+        if obj is None:
+            return None
+        if isinstance(obj, torch.Tensor):
+            return summarize_tensor(obj)
+        # primitive numeric/bool types should return as-is
+        if isinstance(obj, (int, float, bool)):
+            return obj
+        # bytes-like
+        if isinstance(obj, (bytes, bytearray)):
+            return repr(obj)[:20]
+        # path-like
+        if hasattr(obj, "__fspath__"):
+            try:
+                return os.fspath(obj)
+            except Exception:
+                return obj.__class__.__name__
+        if isinstance(obj, dict):
+            return summarize_dict_keys(obj)
+        if isinstance(obj, (list, tuple, set)):
+            return summarize_container(obj)
+        if isinstance(obj, str):
+            return summarize_primitive(obj)
+        # fallback: prefer class name for custom objects
+        if hasattr(obj, "__class__"):
+            # small builtins already handled above
+            # show as ClassName(...) to indicate a stateful/custom object
+            try:
+                return f"{obj.__class__.__name__}(...)"
+            except Exception:
+                return obj.__class__.__name__
+        return summarize_primitive(obj)
+    except Exception:
+        return f"<error summarizing {obj.__class__.__name__}>"
+
+
+def state_to_dict(
+    obj: Any,
+    *,
+    custom_key_transforms: dict[str, Callable[[Any], Any]] | None = None,
+) -> dict:
+    """Generalized state summarizer: produce a dict for `obj` by reading `obj._obj_summ_map`.
+
+    - obj must define `_obj_summ_map` as a dict mapping attribute_name -> label
+    - custom_key_transforms: mapping of attribute_name -> function(value) for special handling
+    """
+    out: dict = {}
+    custom_key_transforms = custom_key_transforms or {}
+
+    obj_summ_map = getattr(obj, "_obj_summ_map", None)
+    if not isinstance(obj_summ_map, dict):
+        raise AttributeError("object must define _obj_summ_map as dict(attribute_name -> label)")
+
+    # keys are the attribute names to read from the object
+    keys = list(obj_summ_map.keys())
+
+    for k in keys:
+        try:
+            v = getattr(obj, k)
+            if k in custom_key_transforms:
+                try:
+                    out[k] = custom_key_transforms[k](v)
+                except Exception:
+                    out[k] = f"<error transform {k}>"
+            else:
+                out[k] = summarize_obj(v)
+        except Exception as exc:
+            out[k] = "<error: {}>".format(exc.__class__.__name__)
+    return out
+
+
+def state_to_summary(
+    state_dict: dict,
+    obj: Any,
+    max_items: int = 10,
+) -> str:
+    """Generalized compact single-line summary builder.
+
+    - state_dict: output from state_to_dict
+    - mapping: list of (label, key) pairs where key corresponds to state_dict keys (may be private or short)
+    Returns a parenthesized string like "(device=cpu, epoch=3, ...)" (no class name).
+    """
+    parts: list[str] = []
+    obj_summ_map = getattr(obj, "_obj_summ_map", None)
+    if not isinstance(obj_summ_map, dict):
+        raise AttributeError("object must define _obj_summ_map as dict(attribute_name -> label)")
+
+    # mapping is list of (label, key) in insertion order of the dict
+    mapping = [(label, key) for key, label in obj_summ_map.items()]
+
+    for label, key in mapping[:max_items]:
+        val = state_dict.get(key, None)
+        if isinstance(val, dict) and val.get("type"):
+            display = f"{val.get('type')}({val.get('len')})"
+        elif isinstance(val, (list, tuple)):
+            display = f"len={len(val)}"
+        else:
+            display = val
+        parts.append(f"{label}={display}")
+    return f"({', '.join(parts)})"
+
+
+def state_repr(summary: str, class_name: str) -> str:
+    """Format a repr for class_name using the provided parenthesized summary.
+
+    If formatting fails, return class_name(<unavailable>).
+    """
+    try:
+        if not summary:
+            return f"{class_name}(<unavailable>)"
+        # summary is expected to be parenthesized like "(a=1, b=2)"
+        return f"{class_name}{summary}"
+    except Exception:
+        return f"{class_name}(<unavailable>)"

--- a/tests/base_defaults.py
+++ b/tests/base_defaults.py
@@ -94,6 +94,7 @@ class BaseCfg:
     force_prepare_data: bool = False  # TODO: make this settable via an env variable as well
     max_steps: Optional[int] = None
     save_checkpoints: bool = False
+    req_deterministic: bool = False
 
     def __post_init__(self):
         self.adapter_ctx = ADAPTER_REGISTRY.canonicalize_composition(self.adapter_ctx)

--- a/tests/core/test_components_mixins.py
+++ b/tests/core/test_components_mixins.py
@@ -278,7 +278,10 @@ class TestGenerativeStepMixin:
 
         # Create a minimal mixin instance for testing
         generative_mixin = GenerativeStepMixin()
-        generative_mixin.GEN_PREPARES_INPUTS_SIGS = ("_prepare_model_inputs",)
+        from interpretune.base.metadata import ITClassMetadata
+
+        # replace class-level metadata for the purpose of this test
+        type(generative_mixin)._it_cls_metadata = ITClassMetadata(gen_prepares_inputs_sigs=("_prepare_model_inputs",))
 
         # Test when model has the prepare method
         model_with_prepare = mock.Mock(spec=["_prepare_model_inputs"])

--- a/tests/core/test_itstate_repr.py
+++ b/tests/core/test_itstate_repr.py
@@ -1,0 +1,79 @@
+from interpretune.config import ITState
+from interpretune.config.transformer_lens import ITLensCustomConfig
+from interpretune.session import ITSession
+from interpretune.base.modules import BaseITModule
+
+
+def test_itstate_basic_summary_shows_values(tmp_path):
+    st = ITState()
+    # set values
+    st._current_epoch = 0
+    st._global_step = 5
+    st._log_dir = tmp_path / "logs"
+    st._session_complete = False
+    st._init_hparams = {"a": {"nested": 1}, "b": "long-string-value-that-will-be-truncated", "c": 123}
+
+    s = repr(st)
+    assert "epoch=0" in s or "epoch=0" in s
+    assert "step=5" in s
+    # log_dir should be shown as a path string
+    assert str(st._log_dir) in s
+    # session_complete should be visible as False
+    assert "session_complete=False" in s
+    # init_hparams should be present (private key preserved) and include keys a,b,c
+    assert "_init_hparams" in st.to_dict()
+    init = st.to_dict()["_init_hparams"]
+    assert "a" in init and "b" in init and "c" in init
+    # dict values should be summarized as {...}
+    assert init["a"] == "{...}"
+    # string value truncated representation
+    assert isinstance(init["b"], str) and len(init["b"]) <= 20
+    # numeric value preserved
+    assert init["c"] == 123
+
+
+def test_itstate_extensions_and_custom_obj_repr(tmp_path):
+    st = ITState()
+    st._extensions = {"debug_lm": None, "memprofiler": None}
+    # custom config object; avoid running __post_init__ which tries to build a HookedTransformerConfig
+    tlc = object.__new__(ITLensCustomConfig)
+    tlc.cfg = {"n_layers": 2, "n_heads": 2}
+    st._init_hparams = {"tl_cfg": tlc}
+    d = st.to_dict()
+    assert "_extensions" in d and isinstance(d["_extensions"], dict)
+    assert d["_extensions"]["debug_lm"] is None
+    # init_hparams should show the custom class with parentheses
+    assert "_init_hparams" in d
+    assert isinstance(d["_init_hparams"]["tl_cfg"], str)
+    assert d["_init_hparams"]["tl_cfg"].startswith("ITLensCustomConfig(")
+
+
+def test_session_and_module_repr_include_state(tmp_path):
+    st = ITState()
+    st._current_epoch = 1
+
+    # create a minimal dummy instance that mimics a module with _it_state
+    class SimpleModule:
+        pass
+
+    simple = SimpleModule()
+    simple._it_state = st
+    # build a minimal BaseITModule-like instance without calling its __init__
+    DummyBase = type("DummyBase", (BaseITModule,), {})
+    dummy_inst = object.__new__(DummyBase)
+    # set attributes expected by BaseITModule.__repr__
+    dummy_inst._it_state = st
+    dummy_inst.model = simple
+
+    # ITSession repr using the dummy module
+    it_session = object.__new__(ITSession)
+    it_session.datamodule = None
+    it_session.module = dummy_inst
+    srepr = repr(it_session)
+    assert "ITSession(" in srepr
+    assert "module=DummyBase" in srepr or "module=DummyBase" in srepr
+
+    # BaseITModule repr should include ITState summary and model class
+    mod_repr = repr(dummy_inst)
+    assert "ITState(" in mod_repr
+    assert "model=" in mod_repr

--- a/tests/orchestration.py
+++ b/tests/orchestration.py
@@ -300,7 +300,9 @@ def init_lightning_trainer(it_session: ITSession, test_cfg: tuple, tmp_path: Pat
     trainer = Trainer(
         default_root_dir=tmp_path,
         devices=1,
-        deterministic=True,
+        # Avoid enabling deterministic globally here; tests should opt-in via the
+        # `make_deterministic` fixture or `make_deterministic_session` when needed.
+        deterministic=False,
         accelerator=accelerator,
         max_epochs=test_cfg.max_epochs,
         precision=lightning_prec_alias(test_cfg.precision),

--- a/tests/parity_acceptance/cfg_aliases.py
+++ b/tests/parity_acceptance/cfg_aliases.py
@@ -32,6 +32,18 @@ bf16 = {"precision": "bf16"}
 cuda_bf16 = {**cuda, **bf16}
 cuda_bf16_l = {**cuda, **bf16, **w_lit}
 
+
+################################################################################
+# Determinism cfg aliases
+################################################################################
+req_det = {"req_deterministic": True}
+req_det_l = {"req_deterministic": True, **w_lit}
+req_det_cuda = {"req_deterministic": True, **cuda}
+req_det_cuda_l = {"req_deterministic": True, **cuda, **w_lit}
+req_det_cuda_bf16 = {"req_deterministic": True, **cuda, **bf16}
+req_det_cuda_bf16_l = {"req_deterministic": True, **cuda, **bf16, **w_lit}
+
+
 ################################################################################
 # Extension cfg aliases
 ################################################################################


### PR DESCRIPTION
## PR description

### Summary
This PR introduces structured class-level metadata and safe, compact object repr helpers across Interpretune and applies small, targeted type- and repr-related fixes to core classes and tests. The changes enable consistent, low-cost repr output for stateful objects (for example `ITState`, sessions, and modules) and consolidate scattered class constants into a single typed container to reduce attribute clutter and improve discoverability.

---

### Main changes

- Add a typed metadata container
  - `metadata.py`
    - New frozen dataclass `ITClassMetadata` that centralizes common class-level settings used by core types (e.g., base/composition attributes, core->framework attribute mappings, property composition rules, and generation sigs).

- Add safe object summary / repr helper utilities
  - `repr_helpers.py`
    - `summarize_obj`, `summarize_tensor`, `summarize_container` and helpers to create cheap, JSON-serializable summaries for common objects.
    - `state_to_dict`, `state_to_summary`, and `state_repr` to support compact, single-line `__repr__` implementations driven by a per-class `_obj_summ_map`.

- Use metadata container and repr helpers in core code
  - `lightning.py`
    - Replace ad-hoc `CORE_TO_FRAMEWORK_ATTRS_MAP` / `PROPERTY_COMPOSITION` with `_it_cls_metadata = ITClassMetadata(...)` including `core_to_framework_attrs_map` and `property_composition`.
  - `core.py`
    - `PropertyDispatcher` now uses `_it_cls_metadata` rather than scattered class-level constants. Calls reading `core_to_framework_attrs_map` and `property_composition` are routed through the metadata instance.
  - `mixins.py`
    - `GenerativeStepMixin` uses `_it_cls_metadata.gen_prepares_inputs_sigs` instead of a raw tuple constant.
  - `modules.py`
    - `BaseITModule.__repr__` added to present a concise summary of module + `ITState` where available (defensive and falls back to superclass `__repr__` on error).
  - `module.py`
    - `ITState` now exposes `_obj_summ_map`, `to_dict()`, custom transform helpers for init hparams/extensions, and `__repr__` using the new `repr_helpers` utilities.
  - `session.py`
    - `ITSession` now defines `_it_cls_metadata` with `base_attrs`, `ready_attrs`, `composition_target_attrs`, and `ready_protocols`. Several methods now read from this metadata (composition and readiness checks). A defensive `__repr__` was added to print a compact session summary (datamodule/module names + `ITState` summary when available).

- Tests updated to accommodate the new metadata API
  - `conftest.py`
    - Fixture `make_deterministic` scope tightened to function (we also add a session-based variant) to avoid cross-test contamination caused by temporary metadata mutation in tests.
  - `test_components_core.py`
    - Test updated to temporarily mutate the metadata mapping via `type(obj)._it_cls_metadata.core_to_framework_attrs_map` and restore it in a `finally`-block to avoid leaking state across tests.
  - `test_components_mixins.py`
    - Tests that previously set `GEN_PREPARES_INPUTS_SIGS` now replace `type(obj)._it_cls_metadata` in test time to emulate class-level metadata changes.

- Documentation / contributing
  - `CONTRIBUTING.md` was extended with developer guidance showing how to use the new `repr_helpers` and the `_it_cls_metadata` pattern, including examples for adding custom transforms and overriding class metadata safely.

---

### Determinism & test configuration changes (new)
- Test-level determinism fixtures
  - Introduced clearer, test-level determinism fixtures and usage patterns so tests opt into deterministic behavior without leaking global state:
    - `make_deterministic` is a lightweight, function-scoped fixture that activates deterministic algorithms for the duration of a test and restores previous state afterwards.
    - `make_deterministic_session` (where used) remains available as an explicit opt-in session fixture but is not applied globally.
  - Tests that require deterministic execution now explicitly opt-in via these fixtures or package-level marks. This reduces flakiness and avoids unexpected deterministic enables during test collection.

- CUBLAS configuration scoping
  - We now set CUBLAS_WORKSPACE_CONFIG before generating fixtures to increase the number of tests that can be configured to require deterministic behavior (determinism flexibility at some cost of test performance)
  - Guidance in `CONTRIBUTING.md` documents expected patterns when enabling determinism in tests (set `CUBLAS_WORKSPACE_CONFIG` early or use the provided package-scoped fixture).

---

### Why
- Avoids printing or materializing large objects (tensors, nested configs) in `__repr__`, which can be expensive or unsafe in interactive debugging and tests.
- Reduces class attribute clutter by consolidating many small, internal constants into a single typed, discoverable container.
- Provides a consistent, testable approach for deriving compact summaries of core objects across the codebase.
- Improves test safety by ensuring metadata changes done in tests are localized and restored.
- Makes deterministic testing predictable and localized: tests explicitly opt into deterministic behavior, and required environment configuration for deterministic CuBLAS is scoped to packages that need it.

---

### Compatibility notes & migration
- Code that previously read `CLASS.CONSTANT_NAME` should be migrated to read values from `CLASS._it_cls_metadata` (for example `CLASS._it_cls_metadata.core_to_framework_attrs_map[...]`) if relying on the new consolidated metadata.
- Tests or third-party extensions that mutate class-level mappings should mutate the nested maps (for example `type(obj)._it_cls_metadata.core_to_framework_attrs_map[...] = ...`) and restore them, rather than replacing the entire `_it_cls_metadata` dataclass unless intended.
- When enabling deterministic execution in tests, either:
  - Use the provided `make_deterministic` fixture (function-scoped), the session-scoped version where appropriate, or for parity_acceptance tests that support it set req_deterministic to True for the relevant tests

---

### Testing & validation
- Test changes included to ensure tests don't leak metadata state across the suite.
- Added safe, defensive `__repr__` implementations that fall back to default behavior on exceptions.
- Determinism tests:
  - allow more flexibility in applying  `make_deterministic` fixture determinism on test-by-test basis