### PR TITLE
FTS TransformerBridge Plugin Support with TL-Style Naming

### DIFF
--- a/.azure-pipelines/gpu-tests.yml
+++ b/.azure-pipelines/gpu-tests.yml
@@ -218,7 +218,7 @@ jobs:
           gpg --no-default-keyring --keyring trustedkeys.gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
           shasum -a 256 -c codecov.SHA256SUM
           chmod +x codecov
-          ./codecov upload-process --slug 'speediedan/interpretune' -t $CODECOV_TOK --commit-sha $(Build.SourceVersion) --git-service 'github' -n "GPU-coverage" -F 'gpu,pytest' --env 'linux,azure' -f 'coverage.xml'
+          ./codecov upload-process --slug 'speediedan/interpretune' -t $CODECOV_TOK --commit-sha $(Build.SourceVersion) --git-service 'github' -n "GPU-coverage" -F gpu -F pytest --env 'linux,azure' -f 'coverage.xml'
         displayName: 'Upload Coverage to Codecov'
         env:
           CODECOV_TOK: $(CODECOV_TOKEN)
@@ -239,6 +239,7 @@ jobs:
       #   env:
       #     PYTORCH_KERNEL_CACHE_PATH: "/__w/_temp/kernel_cache"
       #   displayName: 'Testing: Extended profile and optional tests'
+
       - bash: |
           # since we use rootless docker and userns-remapping, we need to ensure all files/directories in previous
           # steps that may have been written with Azure's `az_pipeline_agent_azpcontainer` user (100997 in the host

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Repository Overview
 
-**Interpretune** is a flexible, powerful framework for collaborative LLM world model analysis and tuning. This project is in **pre-MVP** stage - features and APIs are subject to change.
+**Interpretune** is a flexible, powerful framework for collaborative AI world model analysis and tuning. This project is in **pre-MVP** stage - features and APIs are subject to change.
 
 **Key Technologies:**
 - Python 3.10+ (CI tests on 3.12)
@@ -305,10 +305,15 @@ We now have a separate Azure DevOps pipeline that runs GPU/standalone tests on a
 Note: the GPU pipeline runs only when a PR is ready for review and an admin approves the run — do not expect it to run automatically for draft PRs or early-stage work.
 
 ### Manual Validation Steps
+Set environment context variables (developer-specific paths):
 
 ```bash
-# Activate your environment first
-source ~/.venvs/it_latest/bin/activate
+export IT_VENV_BASE=/mnt/cache/${USER}/.venvs
+export IT_TARGET_VENV=it_latest
+export IT_REPO_DIR=${HOME}/repos/interpretune  # Example: adjust to your local repo path
+
+cd ${IT_REPO_DIR} && \
+source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate
 
 # Run ruff linting (configured in pyproject.toml)
 # we don't have ruff installed as a separate package but use it via pre-commit (with the --fix flag)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -421,11 +421,21 @@ Then run specific tests using **inline environment variables** (not export) to a
 cd ${IT_REPO_DIR} && \
 source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
 IT_RUN_STANDALONE_TESTS=1 python -m pytest tests/examples/test_notebooks.py::test_attribution_analysis_notebook[analysis_inj_salient_logits_SLT] -v
+unset IT_RUN_STANDALONE_TESTS
 
 # Run specific profiling test
 cd ${IT_REPO_DIR} && \
 source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
 IT_RUN_PROFILING_TESTS=1 python -m pytest tests/parity_acceptance/test_it_l.py::test_l_profiling[test_cuda_32_l] -v
+unset IT_RUN_PROFILING_TESTS
+
+# Run specific optional tests
+export IT_RUN_OPTIONAL_TESTS=1 && \
+cd ${IT_REPO_DIR} && \
+source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
+python -m pytest tests/parity_acceptance/test_it_fts.py::test_parity_fts[train_cuda_32_l_tl_bridge_fts] -v  || true && \
+python -m pytest tests/parity_acceptance/test_it_fts.py::test_parity_fts[train_cuda_32_l_tl_bridge_fts_restore] -v  || true && \
+unset IT_RUN_OPTIONAL_TESTS
 ```
 
 **Important Notes:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -433,8 +433,7 @@ unset IT_RUN_PROFILING_TESTS
 export IT_RUN_OPTIONAL_TESTS=1 && \
 cd ${IT_REPO_DIR} && \
 source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
-python -m pytest tests/parity_acceptance/test_it_fts.py::test_parity_fts[train_cuda_32_l_tl_bridge_fts] -v  || true && \
-python -m pytest tests/parity_acceptance/test_it_fts.py::test_parity_fts[train_cuda_32_l_tl_bridge_fts_restore] -v  || true && \
+python -m pytest tests/parity_acceptance/test_it_fts.py::test_parity_fts[train_cuda_32_l_fts] -v  || true && \
 unset IT_RUN_OPTIONAL_TESTS
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -325,6 +325,56 @@ pre-commit run ruff-format --all-files
 pre-commit run --all-files
 ```
 
+### Coverage Collection
+
+Use the `gen_it_coverage.sh` script to collect comprehensive test coverage locally. This script runs all tests including standalone and special tests, then generates a coverage report.
+
+**Handling conflicting processes:**
+
+The `manage_standalone_processes.sh` harness checks for conflicting pytest processes before starting. If you encounter a conflict:
+- If the process is hung or old (>40 minutes), kill it: `pkill -f "pytest.*--collect-only"`
+- If recently started (<40 minutes), wait a few minutes for it to complete naturally
+
+**Monitoring progress:**
+
+```bash
+# Tail the most recent coverage log
+tail -f `ls -rt /tmp/gen_it_coverage_it_* | tail -1`
+```
+
+**Common coverage commands:**
+
+```bash
+# Generate coverage with no rebuild (recommended for quick iteration)
+~/repos/interpretune/scripts/manage_standalone_processes.sh --use-nohup \
+  ~/repos/interpretune/scripts/gen_it_coverage.sh \
+  --repo-home=${HOME}/repos/interpretune \
+  --target-env-name=it_latest \
+  --venv-dir=/mnt/cache/${USER}/.venvs \
+  --no-rebuild-base
+
+# Generate coverage with rebuild (use when dependencies changed)
+~/repos/interpretune/scripts/manage_standalone_processes.sh --use-nohup \
+  ~/repos/interpretune/scripts/gen_it_coverage.sh \
+  --repo-home=${HOME}/repos/interpretune \
+  --target-env-name=it_latest \
+  --venv-dir=/mnt/cache/${USER}/.venvs
+
+# Note: Coverage collection takes approximately 30-35 minutes
+```
+
+**Flags:**
+
+- `--no-rebuild-base`: Skips environment rebuild (faster, use when dependencies haven't changed)
+- `--venv-dir`: Base directory for venvs (recommended: `/mnt/cache/${USER}/.venvs` for hardlink performance)
+- `--run-all-and-examples`: Include additional example tests (extends runtime)
+
+**Output:**
+
+- Coverage report written to `/tmp/current_interpretune_coverage.out`
+- Detailed logs in `/tmp/gen_it_coverage_it_latest_<timestamp>.log`
+- HTML coverage report in `htmlcov/` directory
+
 ### Updating dependencies
 
 When updating dependencies, edit `pyproject.toml` and regenerate locked requirements:
@@ -388,18 +438,34 @@ Full repository type-checking is a work in progress. Current local checks may on
 
 Some tests require special environment setup and are marked with `@pytest.mark.standalone` or involve profiling. These tests can be run using the `special_tests.sh` harness or manually with environment variables.
 
+Set environment context variables (developer-specific paths):
+
+```bash
+export IT_VENV_BASE=/mnt/cache/${USER}/.venvs
+export IT_TARGET_VENV=it_latest
+export IT_REPO_DIR=${HOME}/repos/interpretune  # Example: adjust to your local repo path
+```
+
 **Using the test harness:**
 ```bash
 export IT_REPO_DIR=${HOME}/repos/interpretune  # Example: adjust to your local repo path
 # Run all standalone tests
-cd ${IT_REPO_DIR} && ./tests/special_tests.sh --mark_type=standalone
+cd ${IT_REPO_DIR} && \
+source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
+ ./tests/special_tests.sh --mark_type=standalone
 
 # Run specific standalone test by filter pattern
 cd ${IT_REPO_DIR} && \
+source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
 ./tests/special_tests.sh --mark_type=standalone --filter_pattern='test_attribution_analysis_notebook[analysis_inj_salient_logits_SLT]'
-
+# another example, filtering by partial test class name
+cd ${IT_REPO_DIR} && \
+source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
+./tests/special_tests.sh --mark_type=standalone --filter_pattern='ParameterMapping'
 # Run profiling tests
-cd ${IT_REPO_DIR} && ./tests/special_tests.sh --mark_type=profiling
+cd ${IT_REPO_DIR} && \
+source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
+./tests/special_tests.sh --mark_type=profiling
 ```
 
 **Manual execution (without harness):**
@@ -421,6 +487,13 @@ Then run specific tests using **inline environment variables** (not export) to a
 cd ${IT_REPO_DIR} && \
 source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
 IT_RUN_STANDALONE_TESTS=1 python -m pytest tests/examples/test_notebooks.py::test_attribution_analysis_notebook[analysis_inj_salient_logits_SLT] -v
+unset IT_RUN_STANDALONE_TESTS
+
+# another example using inline variable assignment with multiple standalone tests invoked separately
+cd ${IT_REPO_DIR} && \
+source ${IT_VENV_BASE}/${IT_TARGET_VENV}/bin/activate && \
+IT_RUN_STANDALONE_TESTS=1 python -m pytest tests/core/test_transformer_lens.py::TestGemma2ParameterMapping::test_gemma2_tl_param_structure -v
+IT_RUN_STANDALONE_TESTS=1 python -m pytest tests/core/test_transformer_lens.py::TestLlama3ParameterMapping::test_llama3_tl_param_structure -v
 unset IT_RUN_STANDALONE_TESTS
 
 # Run specific profiling test

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Interpretune
 
-Interpretune: A flexible, powerful framework for collaborative LLM world model analysis and tuning.
+Interpretune: A flexible, powerful framework for collaborative AI world model analysis and tuning.
 
 > **Status:** Pre-MVP (Minimum Viable Product) – Active development, not yet feature complete.
 
 ## Overview
 Interpretune aims to provide tools and infrastructure for:
-- Analyzing large language model (LLM) world models
+- Analyzing AI world models
 - Collaborative research with shareable/composable experimentation
 - Flexible tuning and interpretability workflows
 

--- a/dockers/base-cuda/Dockerfile
+++ b/dockers/base-cuda/Dockerfile
@@ -100,8 +100,8 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 RUN \
     echo "=== Post-ENV permission check ===" && \
     ls -ld /tmp/venvs/it_dev && \
-    echo "Checking torch __pycache__ permissions:" && \
-    find /tmp/venvs/it_dev -type d -path "*/torch/__pycache__" | head -3 | xargs ls -ld || echo "No torch __pycache__ found" && \
+    echo "Checking __pycache__ permissions (sample):" && \
+    find /tmp/venvs/it_dev -type d -name "__pycache__" | head -5 | xargs ls -ld || echo "No __pycache__ found" && \
     echo "=== Post-ENV check complete ==="
 
 RUN \
@@ -119,6 +119,6 @@ RUN \
     echo "============= Environment Verification Complete =============" && \
     # Apply recursive chmod to allow userns-remapped rootless Docker users to update the venv
     chmod -R 777 /tmp/venvs/it_dev && \
-    echo "Verify permission state:" && \
-    find /tmp/venvs/it_dev -type d -path "*/torch/__pycache__" | head -3 | xargs ls -ld || echo "No torch __pycache__ found" && \
+    echo "Verify permission state after final chmod:" && \
+    find /tmp/venvs/it_dev -type d -name "__pycache__" | head -5 | xargs ls -ld || echo "No __pycache__ found" && \
     echo "=== Post-env-check chmod complete ==="

--- a/docs/fts_transformerlens_integration.md
+++ b/docs/fts_transformerlens_integration.md
@@ -11,6 +11,86 @@ FinetuningScheduler enables flexible fine-tuning through YAML-based schedules th
 3. **TransformerLens - TransformerBridge** - Modern names using canonical `_original_component` wrapper references
 4. **TransformerLens - TransformerBridge TL Names Mode** - Modern TL-style naming
 
+## Usage
+
+### Plugin Registration
+
+Interpretune registers the `TransformerBridgeStrategyAdapter` as a FinetuningScheduler plugin via entry points in `pyproject.toml`:
+
+```toml
+[project.entry-points."finetuning_scheduler.strategy_adapters"]
+transformerbridge = "interpretune.adapters.transformer_lens:TransformerBridgeStrategyAdapter"
+```
+
+This allows the adapter to be discovered and used by FTS without requiring direct imports.
+
+### Basic Usage
+
+```python
+from finetuning_scheduler import FinetuningScheduler
+from interpretune import InterpretunableModule
+from interpretune.config import ITLensBridgeConfig
+
+# Configure TransformerBridge model
+tl_cfg = ITLensBridgeConfig(model_name="gpt2-small")
+model = InterpretunableModule(tl_cfg=tl_cfg)
+
+# Create FTS callback using the registered plugin
+# Map Lightning strategy flags to the adapter
+fts = FinetuningScheduler(
+    custom_strategy_adapters={
+        "single_device": "transformerbridge",  # Use plugin name
+        "ddp": "transformerbridge",  # Same adapter for DDP
+    },
+    strategy_adapter_cfg={"use_tl_names": True},  # Enable TL-style naming
+)
+```
+
+**Alternative formats** for specifying the adapter:
+
+```python
+# Using entry point name (recommended)
+custom_strategy_adapters={"single_device": "transformerbridge"}
+
+# Using colon-separated fully qualified path
+custom_strategy_adapters={
+    "single_device": "interpretune.adapters.transformer_lens:TransformerBridgeStrategyAdapter"
+}
+
+# Using dot-separated fully qualified path
+custom_strategy_adapters={
+    "single_device": "interpretune.adapters.transformer_lens.TransformerBridgeStrategyAdapter"
+}
+```
+
+### Configuration Options
+
+The `TransformerBridgeStrategyAdapter` supports two parameter naming modes via `strategy_adapter_cfg`:
+
+**Canonical Mode (default):**
+```python
+fts = FinetuningScheduler(
+    custom_strategy_adapters={"single_device": "transformerbridge"},
+    # No strategy_adapter_cfg needed - canonical mode is default
+)
+```
+Schedules use canonical names like `model.blocks.9._original_component.attn.q._original_component.weight`
+
+**TL Names Mode:**
+```python
+fts = FinetuningScheduler(
+    custom_strategy_adapters={"single_device": "transformerbridge"},
+    strategy_adapter_cfg={"use_tl_names": True},
+)
+```
+Schedules use clean TL-style names like `blocks.9.attn.W_Q`
+
+### Related Documentation
+
+- FTS Plugin Documentation: [Strategy Adapter Entry Points](https://finetuning-scheduler.readthedocs.io/en/latest/plugins/strategy_adapter_entry_points.html)
+- Interpretune TransformerBridge Integration: [TL-Style Naming Implementation](./tl_style_naming_implementation.md)
+- FTS Custom Strategy Adapters: [API Reference](https://finetuning-scheduler.readthedocs.io/en/latest/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler)
+
 ## Parameter Naming Conventions
 
 ### Base (HuggingFace GPT-2)

--- a/docs/fts_transformerlens_integration.md
+++ b/docs/fts_transformerlens_integration.md
@@ -1,0 +1,294 @@
+# FinetuningScheduler Integration with TransformerLens
+
+This document describes how Interpretune integrates FinetuningScheduler (FTS) with TransformerLens architectures (HookedTransformer and TransformerBridge), including parameter naming conventions, schedule generation, and phase-based parameter thawing behavior.
+
+## Overview
+
+FinetuningScheduler enables flexible fine-tuning through YAML-based schedules that specify which parameters to thaw at each training phase. When integrated with TransformerLens, FTS must handle four distinct parameter naming conventions:
+
+1. **HuggingFace Canonical** - Standard PyTorch naming (e.g., `transformer.h.9.attn.c_attn.weight`)
+2. **TransformerLens - HookedTransformer** - Legacy TL naming (e.g., `blocks.9.attn.W_Q`) including LayerNorms in named_parameters()
+3. **TransformerLens - TransformerBridge** - Modern names using canonical `_original_component` wrapper references
+4. **TransformerLens - TransformerBridge TL Names Mode** - Modern TL-style naming
+
+## Parameter Naming Conventions
+
+### Base (HuggingFace GPT-2)
+```yaml
+# Pattern: model.transformer.h.{layer}.(mlp|attn|ln_{1|2}).(c_proj|c_fc|c_attn|weight|bias)
+Examples:
+  - model.transformer.h.9.attn.c_attn.weight
+  - model.transformer.h.10.mlp.c_fc.bias
+  - model.transformer.h.11.ln1.weight
+  - model.transformer.h.11.ln2.bias
+  - model.transformer.wte.weight (embeddings)
+  - model.transformer.ln_f.weight (final LayerNorm)
+```
+
+### HookedTransformer
+```yaml
+# Pattern: model.blocks.{layer}.*
+# Legacy TL names include LayerNorm params
+Examples:
+  - model.blocks.9.attn.W_Q
+  - model.blocks.10.mlp.W_out
+  - model.blocks.11.ln1.w
+  - model.blocks.11.ln2.b
+  - model.embed.W_E (embeddings)
+  - model.unembed.W_U (unembedding)
+```
+
+### TransformerBridge (Canonical Mode)
+```yaml
+# Pattern: model.blocks.{layer}.*
+# Includes _original_component wrappers for compatibility
+Examples:
+  - model.blocks.9._original_component.attn.qkv._original_component.weight
+  - model.blocks.10._original_component.mlp.c_fc._original_component.weight
+  - model.blocks.11._original_component.ln_1._original_component.weight
+  - model.blocks.11._original_component.ln_2._original_component.bias
+  - model.embed._original_component.weight
+  - model.unembed._original_component.weight
+```
+
+### TransformerBridge (TL Names Mode)
+```yaml
+# Pattern: blocks.{layer}.* (no model. prefix)
+# Uses TL-style names, implicitly includes LayerNorms
+Examples:
+  - blocks.9.attn.W_Q
+  - blocks.10.mlp.W_out
+  - embed.W_E
+  - unembed.W_U
+```
+
+## Schedule Generation and Phase Structure
+
+### Base GPT-2 (2-Phase Schedule)
+
+**Schedule:**
+```yaml
+0:
+  max_transition_epoch: 2
+  params:
+  - model.transformer.h.(9|1[0-1]).(mlp|attn|ln_(1|2)).(c_proj|c_fc|c_attn|weight|bias).*
+1:
+  lr: 1.0e-06
+  max_transition_epoch: 3
+  params:
+  - model.transformer.h.([7-8]).(mlp|attn|ln_(1|2)).(c_proj|c_fc|c_attn|weight|bias).*
+2:
+  lr: 1.0e-06
+  params:
+  - model.transformer.h.([0-6](?!\d)).(mlp|attn|ln_(1|2)).(c_proj|c_fc|c_attn|weight|bias).*
+  - model.transformer.(wpe|wte).weight
+  - model.transformer.ln_f.*
+```
+
+**Parameter Counts:**
+- **Phase 0** (blocks 9-11): 36 parameters
+  - blocks 9-11, 3 blocks × (4 attn + 4 mlp + 4 ln params per block) = 36
+  - Params: attn (c_attn, c_proj), mlp (c_fc, c_proj), ln_1, ln_2
+- **Phase 1** (blocks 7-8): 24 additional parameters (60 total)
+  - adds blocks 7-8, +24 params
+- **Phase 2** (blocks 0-6 + embeddings): 88 additional parameters (148 total)
+  - adds blocks 0-6 + embeddings, +88 params
+  - Embeddings: wte, wpe, ln_f (weight + bias)
+
+### HookedTransformer (3-Phase Schedule)
+
+**Schedule:**
+```yaml
+0:
+  max_transition_epoch: 2
+  params:
+    - model.blocks.(9|1[0-1]).*
+1:
+  lr: 1.0e-06
+  max_transition_epoch: 3
+  params:
+    - model.blocks.([7-8]).*
+2:
+  lr: 1.0e-06
+  params:
+    - model.blocks.([0-6](?!\d)).*
+    - model.(pos_embed|embed|unembed).*
+```
+
+**Parameter Counts:**
+- **Phase 0** (blocks 9-11): 48 parameters
+  - 3 blocks × 12 TL params/block + 12 LayerNorm params = 48
+  - TL params per block: W_Q, W_K, W_V, W_O, b_Q, b_K, b_V, b_O, W_in, W_out, b_in, b_out
+  - LayerNorm: ln1.w, ln1.b, ln2.w, ln2.b per block (note legacy TL names include explicit LayerNorms)
+- **Phase 1** (blocks 7-8): 32 additional parameters (80 total)
+  - 2 blocks × 12 TL params + 8 LayerNorm params = 32
+- **Phase 2** (blocks 0-6 + embeddings): 116 additional parameters (196 total out of 198 total params)
+  - 7 blocks × 12 TL params + 28 LayerNorm + 4 embed params = 116
+  - Embeddings: W_E, W_pos, W_U, b_U (4 params)
+  - 2 ln_final (ln_final.w and ln_final.b) params remain frozen since we did not specify them in the schedule
+- there are 198 total parameters in named_parameters(), 50 more than in the original HF due to 4 extra attention params per block (4x12) + 2 unembed params
+
+### TransformerBridge Canonical Mode (3-Phase Schedule)
+
+**Schedule:**
+```yaml
+0:
+  max_transition_epoch: 2
+  params:
+    - model.blocks.(9|1[0-1]).*
+1:
+  lr: 1.0e-06
+  max_transition_epoch: 3
+  params:
+    - model.blocks.([7-8]).*
+2:
+  lr: 1.0e-06
+  params:
+    - model.blocks.([0-6](?!\d)).*
+    - model.(pos_embed|embed|unembed).*
+```
+
+**Parameter Counts:**
+- **Phase 0** (blocks 9-11): 54 parameters
+  - 3 blocks × 14 params/block + 12 LayerNorm params = 54
+  - Bridge params per block (via _original_component refs, e.g. `model.blocks.11._original_component.mlp._original_component.c_proj._original_component.bias`):
+    - attn (10, 2 original joined qkv not used but still available): qkv.weight, qkv.bias, q/k/v/o.weight, q/k/v/o.bias
+    - mlp (4): c_fc.weight, c_fc.bias, c_proj.weight, c_proj.bias
+  - **+6 params vs HookedTransformer**: Joint QKV projections stored separately
+- **Phase 1** (blocks 7-8): 36 additional parameters (90 total)
+  - 2 blocks × 14 params + 8 LayerNorm params = 36
+  - **+4 params vs HookedTransformer**: Additional joint QKV params
+- **Phase 2** (blocks 0-6 + embeddings): 129 additional parameters (219 total)
+  - 7 blocks × 14 params + 28 LayerNorm + 3 embed params = 129
+  - **+13 params vs HookedTransformer**: 7 blocks × 2 extra QKV params - 1 untied unembed weight param (unembed only has bias as it remained tied to the embed weight since we specified `enable_compatibility_mode` with `no_processing`)
+  - 2 ln_final params remain frozen since we did not specify them in the schedule
+
+**Key Difference:** TransformerBridge canonical mode stores joint QKV projection parameters separately from the split Q, K, V views. Both are included in the parameter count, resulting in 2 additional parameters per attention layer (qkv.weight + qkv.bias). They are thawed but not used in training.
+
+### TransformerBridge TL Names Mode (3-Phase Schedule)
+
+**Schedule:**
+```yaml
+0:
+  max_transition_epoch: 2
+  params:
+    - blocks.(9|1[0-1]).*
+1:
+  max_transition_epoch: 3
+  params:
+    - blocks.([7-8]).*
+2:
+  lr: 1.0e-06
+  params:
+    - blocks.([0-6](?!\d)).*
+    - (pos_embed|embed|unembed).*
+```
+
+**Parameter Counts:**
+- **Phase 0** (blocks 9-11): 48 parameters
+  - Same as HookedTransformer: 3 blocks × 12 TL params + 12 LayerNorm = 48
+- **Phase 1** (blocks 7-8): 32 additional parameters (80 total)
+  - Same as HookedTransformer: 2 blocks × 12 TL params + 8 LayerNorm = 32
+- **Phase 2** (blocks 0-6 + embeddings): 117 additional parameters (197 total)
+  - Same as HookedTransformer: 7 blocks × 12 TL params + 28 LayerNorm + 3 embed (1 unembed bias) + 2 ln_final layers thawed (since `implicit_ln_thaw` was left to the default of `True`) = 117
+  - 24 total parameters remain unfrozen overall, the 24 (unused) joint qkv parameters
+- since we did not set enable_compatibility_mode, the unembed weight remains tied to the embed weight, so we have only embed.weight, pos_embed.weight and unembed.bias embedding params thawed
+**Key Feature:** TL names mode uses TLNamesModelView to translate between canonical parameter names and TL-style names. The schedule uses TL nomenclature (e.g., `W_Q`, `W_K`) to orchestrate the thawing of the associated underlying canonical parameters during training. Joint QKV parameters remain available but are not thawed since we are driving our training with TL names and as the qkv joint parameters are not used in training they are not mapped to the TL style names.
+
+## LayerNorm Handling
+
+### HookedTransformer (Legacy)
+- **Explicit in Schedule**: LayerNorm parameters (ln1.w, ln1.b, ln2.w, ln2.b, ln_final.w, ln_final.b) are included in named_parameters()
+- **Regex Matching**: Schedule patterns like `blocks.9.*` explicitly match LayerNorm params
+- **Phase Association**: LayerNorm params thaw when their regex pattern matches them in the schedule
+
+### TransformerBridge (Modern v3)
+- Two supported modes, depending on the provided bridge adapter configuration.
+
+#### CanonicalModelView vs TLNamesModelView
+- CanonicalModelView:
+    - When use_tl_names=False (default), the fine-tuning schedule uses direct canonical parameter specification
+  but may expose architectural differences reducing schedule portability
+    - **Explicit Schedule Matching**: Schedule patterns used to match LayerNorm params and they are thawed via canonical named_parameters()
+- TLNamesModelView:
+    - When use_tl_names=True, provides standard TL-style interface for convenient cross-architecture schedules
+    - LayerNorm parameters are NOT included in tl_named_parameters() (used to drive schedule in TL names mode) so we offer the implicit ln thawing option.
+    - **implicit_ln_thaw**: Default True, automatically thaws LayerNorms when their block is thawed
+    - **Regex-Based**: Wildcard patterns like `blocks.9.*` trigger implicit LayerNorm thawing for that block
+
+## Checkpoint Restoration Behavior
+
+With the additive penalty divergence mechanism (implemented for testing), all test configurations show consistent checkpoint restoration behavior:
+
+- **Divergence Starts**: Epoch 2 (first epoch of phase 1)
+- **Best Checkpoint**: Remains at depth 0 (phase 0) throughout training
+- **Restoration**: All architectures correctly restore to the best checkpoint from phase 0
+
+## Implementation Details
+
+### TLNamesModelView
+The `TLNamesModelView` class (in `transformer_lens.py`) provides:
+- **Bidirectional mapping** between TL and canonical parameter names
+- **Component tracing** via `data_ptr()` to match parameters by memory address
+- **Implicit LayerNorm handling** - LayerNorm params excluded from mapping, caught by regex
+- **Transform methods** for converting between naming conventions
+
+### CanonicalModelView
+The `CanonicalModelView` class (in `model_view.py`) provides:
+- **Direct canonical naming** for base HuggingFace models
+- **Standard schedule generation** without name transformations
+- **Explicit parameter matching** via regex patterns
+
+### Schedule Generation Flow
+
+1. **Model Inspection**: Extract trainable parameters with their names
+2. **Name Transformation** (TL Names mode only): Convert canonical → TL names via ModelView
+3. **Regex Pattern Generation**: Create patterns for layer groups (e.g., `blocks.(9|1[0-1]).*`)
+4. **Phase Definition**: Map patterns to training phases with transition epochs
+5. **YAML Serialization**: Write schedule to `{ModuleName}_ft_schedule.yaml`
+
+## Testing Strategy
+
+All FTS integration tests validate:
+- Correct parameter counts per phase
+- Proper schedule generation for each architecture
+- Checkpoint restoration at correct depths
+- Consistent behavior across naming conventions
+
+Test configurations:
+- `train_cpu_32_l_fts`: Base GPT-2 (3-phase)
+- `train_cuda_32_l_tl_ht_fts`: HookedTransformer (3-phase)
+- `train_cuda_32_l_tl_bridge_fts`: TransformerBridge canonical (3-phase)
+- `train_cuda_32_l_tl_bridge_tl_names_fts`: TransformerBridge TL names (3-phase)
+
+## Parameter Count Differences Explained
+
+### Why HookedTransformer has 48 params vs Base 36 params in Phase 0?
+
+**Base (36 params):**
+- 3 blocks × 12 canonical params = 36
+- Attention: c_attn.weight, c_attn.bias, c_proj.weight, c_proj.bias (4 params - joint QKV projection)
+- MLP: c_fc.weight, c_fc.bias, c_proj.weight, c_proj.bias (4 params)
+- LayerNorm: ln_1.weight, ln_1.bias, ln_2.weight, ln_2.bias (4 params)
+
+**HookedTransformer (48 params):**
+- 3 blocks × 16 TL params = 48
+- Attention: W_Q, W_K, W_V, W_O, b_Q, b_K, b_V, b_O (8 params - split Q/K/V projections)
+- MLP: W_in, W_out, b_in, b_out (4 params)
+- LayerNorm: ln1.w, ln1.b, ln2.w, ln2.b (4 params)
+- **Key difference**: HookedTransformer has 8 attention params vs Base's 4 (split Q/K/V vs joint QKV)
+
+### Why TransformerBridge Canonical has 54 params vs HookedTransformer 48 params?
+
+**Additional 6 params:**
+- 3 blocks × 2 params = 6
+- Each attention layer stores joint QKV projection (qkv.weight, qkv.bias)
+- Split Q, K, V parameters are materialized as new parameters for LinearBridge modules
+- Joint and split QKV parameters do NOT share underlying storage - they are separate tensors
+- Result: Bridge has both joint (2 params) and split (6 params) QKV parameters per block
+
+
+## Related Documentation
+
+- [TL Style Naming Implementation](tl_style_naming_implementation.md) - Details on TL parameter name transformations
+- [TL Config Hierarchy](tl_config_hierarchy_overview.md) - TransformerLens configuration architecture

--- a/docs/tl_style_naming_implementation.md
+++ b/docs/tl_style_naming_implementation.md
@@ -1,0 +1,287 @@
+# TransformerLens-Style Parameter Naming Implementation
+
+## Overview
+
+This document describes the implementation of TL-style parameter naming support in FinetuningScheduler (FTS) for use with TransformerBridge models. This feature fosters greater cross-architecture schedule interoperability, allowing users to define fine-tuning schedules using cleaner, more intuitive parameter names from TransformerLens's standardized naming convention.
+
+## Motivation
+
+TransformerBridge models (TransformerLens v3) expose parameters through two interfaces:
+
+1. **Canonical naming** (`named_parameters()`): Uses `_original_component` wrapper prefixes but provides access to canonical parameter names.
+   - GPT-2 Example:
+   - Parameter name: `model.blocks.9._original_component.attn.q._original_component.weight`
+   - Total: 221 parameters (includes LayerNorms and potentially unused parameters like joint QKV params)
+
+2. **TL-style naming** (`tl_named_parameters()`): Clean, standardized names that abstract away architecture-specific details
+   - GPT-2 Example:
+   - Parameter name: `blocks.9.attn.W_Q`
+   - Total: 148 parameters (excludes LayerNorms and maps to used canonical parameters)
+
+The canonical names are necessary for the optimizer's internal state and provide more granular control, but TL-style names are more intuitive for schedule authoring. The TransformerBridgeStrategyAdapter now supports defining fine-tuning schedules using both naming conventions, allowing users to choose the approach that best fits a given use case.
+
+## Architecture
+
+### Phase 1: FTS Core Changes
+
+**Modified Files:**
+- `finetuning-scheduler/src/finetuning_scheduler/strategy_adapters/base.py`
+- `finetuning-scheduler/src/finetuning_scheduler/fts.py`
+- `finetuning-scheduler/src/finetuning_scheduler/fts_supporters.py`
+
+**Changes:**
+1. Moved `gen_ft_schedule` from static method in `ScheduleImplMixin` to instance method on `StrategyAdapter` base class
+2. Updated both call sites to use `self.strategy_adapter.gen_ft_schedule()`
+3. Added deprecation warning (deprecated in 2.10.0, removal in 2.12.0) using `rank_zero_warn`
+
+**Rationale:** Strategy adapters need to customize schedule generation to handle model-specific naming conventions.
+
+### Phase 2: TransformerBridgeStrategyAdapter Implementation
+
+**Modified File:**
+- `interpretune/src/interpretune/adapters/transformer_lens.py`
+
+**Key Components:**
+
+#### 1. Initialization (`__init__`)
+```python
+def __init__(self, use_tl_names: bool = False):
+    super().__init__()
+    self.use_tl_names = use_tl_names
+    self._tl_to_canonical_map: Dict[str, List[str]] = {}
+    self._canonical_to_tl_map: Dict[str, str] = {}
+```
+
+#### 2. Parameter Mapping (`_build_param_mapping`)
+- Uses `tensor.data_ptr()` for robust matching (handles views and aliases correctly)
+- Builds bidirectional mappings:
+  - **TL→canonical** (1:many): One TL name may map to multiple canonical names (e.g., views)
+  - **canonical→TL** (1:1): Each canonical name maps to exactly one TL name
+- Called during initialization if `use_tl_names=True`
+
+#### 3. Schedule→Optimizer Translation (`fts_optim_transform`)
+- Translates TL-style parameter patterns in schedules to canonical names for optimizer
+- Handles regex patterns: `r"blocks.9.*"` → `r"model.blocks.9.*"`
+- Preserves non-TL parameters unchanged (e.g., manually added classifier heads)
+
+#### 4. Optimizer→Schedule Translation (`logical_param_translation`)
+- Translates canonical parameter names back to TL-style for logging/display
+- Uses `_canonical_to_tl_map` for efficient lookup
+- Falls back to canonical names for unmapped parameters
+
+#### 5. ModelView Abstraction
+- Encapsulates parameter naming transformations in a separate ModelView class
+- Two implementations:
+  - **CanonicalModelView**: Identity transformation (default)
+  - **TLNamesModelView**: TL-style naming with bidirectional mapping
+- Each ModelView delegates to base StrategyAdapter methods:
+  - `gen_schedule()` → `StrategyAdapter.gen_ft_schedule(self.adapter, dump_loc)`
+  - `validate_schedule()` → `StrategyAdapter.validate_ft_sched(self.adapter)`
+- This pattern avoids callable parameter passing and provides clean delegation
+
+### Phase 3: Test Infrastructure
+
+**Modified Files:**
+- `interpretune/tests/conftest.py`
+- `interpretune/tests/parity_acceptance/cfg_aliases.py`
+- `interpretune/tests/parity_acceptance/test_it_fts.py`
+- `interpretune/tests/parity_acceptance/expected.py`
+
+**Test Components:**
+
+1. **Schedule Transform** (`tl_bridge_multiphase_explicit_tl_names`):
+   - Defines parameter patterns using TL-style names
+   - Example: `r"blocks.(9|1[0-1]).*"` instead of `r"model.blocks.(9|1[0-1]).*"`
+
+2. **Test Configuration** (`l_tl_bridge_gpt2_fts_multiphase_tl_names`):
+   - Configures FTS with `strategy_adapter_cfg={'use_tl_names': True}`
+   - Uses custom strategy adapter via entry point
+   - Reuses existing test infrastructure (DivergeTestITModule, etc.)
+
+3. **Parity Test** (`test_parity_fts[train_cuda_32_l_tl_bridge_fts_tl_names]`):
+   - Validates that training dynamics work correctly with TL-style naming
+   - Verifies checkpoint compatibility
+   - Ensures optimizer state dict uses canonical names internally
+   - NOTE: Parameter counts may differ from HookedTransformer due to:
+     * LayerNorm handling (explicit vs implicit_ln_thaw)
+     * Unembed weight tying (depends on enable_compatibility_mode)
+     * Joint vs split QKV parameters in underlying architecture
+
+## Usage
+
+### Enabling TL-Style Naming
+
+```python
+from interpretune.adapters.transformer_lens import TransformerBridgeStrategyAdapter
+from finetuning_scheduler import FinetuningScheduler
+
+# Create strategy adapter with TL-style naming
+strategy_adapter_cfg = {'use_tl_names': True}
+
+# Pass to FTS callback
+fts_callback = FinetuningScheduler(
+    strategy_adapter_cfg=strategy_adapter_cfg,
+    # ... other config
+)
+```
+
+### Schedule Example (TL-Style)
+
+```yaml
+0:
+  params:
+    - blocks.(9|1[0-1]).*  # Layers 9-11
+1:
+  params:
+    - blocks.([7-8]).*     # Layers 7-8
+2:
+  params:
+    - blocks.([0-6](?!\d)).*  # Layers 0-6
+    - (pos_embed|embed|unembed).*      # Embeddings
+```
+
+### Schedule Example (Canonical - Default)
+
+```yaml
+0:
+  params:
+    - model.blocks.(9|1[0-1]).*  # Layers 9-11
+1:
+  params:
+    - model.blocks.([7-8]).*     # Layers 7-8
+2:
+  params:
+    - model.blocks.([0-6](?!\d)).*  # Layers 0-6
+    - model.(pos_embed|embed|unembed).*      # Embeddings
+```
+
+## Implementation Details
+
+### Parameter Mapping Strategy
+
+The implementation uses `tensor.data_ptr()` for matching because:
+1. **Handles views correctly**: Different parameter names may reference the same underlying memory
+2. **Robust to name changes**: Matching is based on actual tensor data, not string heuristics
+3. **Efficient**: O(1) lookup via dictionary mapping
+
+Example mapping:
+```python
+# TL→canonical (1:many) (in practice, in most cases 1:1)
+{
+    'blocks.9.attn.W_Q': [
+        'model.blocks.9._original_component.attn.q._original_component.weight'
+    ],
+    'blocks.9.attn.b_Q': [
+        'model.blocks.9._original_component.attn.q._original_component.bias'
+    ],
+}
+
+# canonical→TL (1:1)
+{
+    'model.blocks.9._original_component.attn.q._original_component.weight': 'blocks.9.attn.W_Q',
+    'model.blocks.9._original_component.attn.q._original_component.bias': 'blocks.9.attn.b_Q',
+}
+```
+
+### Translation Functions
+
+**fts_optim_transform** (Schedule→Optimizer):
+```python
+def fts_optim_transform(self, orig_pl: List[List[str]]) -> List[List[str]]:
+    """Translate TL-style patterns to canonical names for optimizer."""
+    # Delegate to the active ModelView for transformation
+    return self.model_view.transform_to_canonical(orig_pl, inspect_only=False)
+```
+
+**logical_param_translation** (Optimizer→Schedule):
+```python
+def logical_param_translation(self, param_names: List[str]) -> List[str]:
+    """Translate canonical names to TL-style for logging/display."""
+    # Delegate to the active ModelView for transformation
+    return self.model_view.transform_from_canonical(param_names)
+```
+
+**ModelView Delegation Pattern:**
+```python
+class CanonicalModelView(ModelView):
+    def gen_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
+        """Generate schedule with canonical naming."""
+        from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+        return StrategyAdapter.gen_ft_schedule(self.adapter, dump_loc)
+
+    def validate_schedule(self) -> Tuple[int, int]:
+        """Validate schedule with canonical naming."""
+        from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+        return StrategyAdapter.validate_ft_sched(self.adapter)
+
+class TLNamesModelView(ModelView):
+    def gen_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
+        """Generate schedule using TL-style naming."""
+        # Custom implementation using tl_named_parameters()
+        ...
+
+    def validate_schedule(self) -> Tuple[int, int]:
+        """Validate schedule with TL-style diagnostics."""
+        # Log mapping diagnostics
+        rank_zero_debug(...)
+
+        # Delegate to base StrategyAdapter
+        from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+        return StrategyAdapter.validate_ft_sched(self.adapter)
+```
+
+## Testing
+
+### Parity Test Strategy
+
+The parity test validates that TL-style naming mode produces identical training dynamics:
+
+1. **Training Metrics**: Loss, accuracy, etc. should match exactly
+2. **Callback State**: FTS depth transitions, parameter counts should be identical
+3. **Checkpoint Compatibility**: Saved checkpoints should restore correctly
+
+### Test Configuration
+
+```python
+# Test alias: train_cuda_32_l_tl_bridge_fts_tl_names
+FTSParityTest(
+    alias="train_cuda_32_l_tl_bridge_fts_tl_names",
+    cfg=FTSParityCfg(
+        **l_tl_bridge_gpt2_fts_multiphase_tl_names,
+        **cuda
+    ),
+    marks="cuda_alone",
+)
+```
+
+## Backward Compatibility
+
+### Default Behavior
+- `use_tl_names=False` (default): Uses canonical naming (backward compatible)
+- All existing schedules continue to work unchanged
+
+### Deprecation
+- Static `ScheduleImplMixin.gen_ft_schedule()` deprecated in 2.10.0
+- Will be removed in 2.12.0
+- Uses `rank_zero_warn` for deprecation notice
+
+### Migration Path
+1. Users can opt-in to TL-style naming via `strategy_adapter_cfg`
+2. No breaking changes to existing functionality
+3. Clear deprecation warnings guide users to new API
+
+## Future Work
+
+### Potential Enhancements
+1. **Auto-detection**: Automatically enable `use_tl_names` for TransformerBridge models
+2. **Mixed naming**: Support mixing TL-style and canonical names in same schedule
+3. **Custom mappings**: Allow users to define custom name translation rules
+4. **Validation**: Enhance schedule validation to catch more common error patterns
+
+### Related Features
+1. **FSDP support**: Ensure TL-style naming works with FSDP strategy
+2. **Documentation**: User guide with examples and best practices
+
+## References
+
+- [FinetuningScheduler Documentation](https://finetuning-scheduler.readthedocs.io/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ transformerbridge = "interpretune.adapters.transformer_lens:TransformerBridgeStr
 [project.optional-dependencies]
 
 lightning = [
-    "finetuning-scheduler >= 2.5.0",
+    # commenting out when installing from git urls to avoid dep conflicts
+    # "finetuning-scheduler >= 2.10.0",
     "bitsandbytes; platform_system != 'Darwin'",
     "peft",
 ]
@@ -92,6 +93,7 @@ examples = [
 git-deps = [
     "circuit-tracer @ git+https://github.com/speediedan/circuit-tracer.git@004f1b2822eca3f0c1ddd2389e9105b3abffde87",
     "transformer-lens @ git+https://github.com/speediedan/TransformerLens.git@d35d01feb9cc076a091e41255e1c9f92de2af236",
+    "finetuning-scheduler @ git+https://github.com/speediedan/finetuning-scheduler.git@4aa64032c07acd34493a5c05929845bd011426c9",
     "sae_lens >= 6.3.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dependencies = [
 [project.entry-points."console_scripts"]
 interpretune = "interpretune.base.components.cli:bootstrap_cli"
 
+[project.entry-points."finetuning_scheduler.strategy_adapters"]
+transformerbridge = "interpretune.adapters.transformer_lens:TransformerBridgeStrategyAdapter"
+
 [project.optional-dependencies]
 
 lightning = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ examples = [
 # Update commit hashes when cutting release branches to pin to tested versions
 git-deps = [
     "circuit-tracer @ git+https://github.com/speediedan/circuit-tracer.git@004f1b2822eca3f0c1ddd2389e9105b3abffde87",
-    "transformer-lens @ git+https://github.com/speediedan/TransformerLens.git@770588a002666d463623e76fa0277c98ad8793e4",
+    "transformer-lens @ git+https://github.com/speediedan/TransformerLens.git@d35d01feb9cc076a091e41255e1c9f92de2af236",
     "sae_lens >= 6.3.1",
 ]
 
@@ -146,7 +146,7 @@ profiling = [
 # from source we also include this version to ensure it is respected when installing without the
 # --override flag (e.g CI)
 override-dependencies = [
-    "transformer-lens @ git+https://github.com/speediedan/TransformerLens.git@770588a002666d463623e76fa0277c98ad8793e4",
+    "transformer-lens @ git+https://github.com/speediedan/TransformerLens.git@d35d01feb9cc076a091e41255e1c9f92de2af236",
 ]
 # exclude dependencies can be used to ignore installation of a dependency altogether (transitive or direct)
 # we occasionally use an excludes file to allow complex multiple-packages-from-source installations

--- a/requirements/ci/overrides.txt
+++ b/requirements/ci/overrides.txt
@@ -1,1 +1,1 @@
-transformer-lens @ git+https://github.com/speediedan/TransformerLens.git@770588a002666d463623e76fa0277c98ad8793e4
+transformer-lens @ git+https://github.com/speediedan/TransformerLens.git@d35d01feb9cc076a091e41255e1c9f92de2af236

--- a/requirements/ci/requirements.txt
+++ b/requirements/ci/requirements.txt
@@ -6,7 +6,7 @@ accelerate==1.12.0
     # via peft
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.2
+aiohttp==3.13.3
     # via
     #   fsspec
     #   papermill
@@ -16,7 +16,7 @@ annotated-types==0.7.0
     # via pydantic
 ansicolors==1.1.8
     # via papermill
-anyio==4.11.0
+anyio==4.12.1
     # via
     #   httpx
     #   jupyter-server
@@ -39,15 +39,15 @@ attrs==25.4.0
     #   referencing
 babel==2.17.0
     # via jupyterlab-server
-beautifulsoup4==4.14.2
+beautifulsoup4==4.14.3
     # via
     #   gdown
     #   nbconvert
-bitsandbytes==0.48.2 ; sys_platform != 'darwin'
+bitsandbytes==0.49.1 ; sys_platform != 'darwin'
     # via interpretune (pyproject.toml)
 bleach[css]==6.3.0
     # via nbconvert
-certifi==2025.11.12
+certifi==2026.1.4
     # via
     #   httpcore
     #   httpx
@@ -78,7 +78,7 @@ comm==0.2.3
     #   ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage==7.12.0
+coverage==7.13.1
     # via
     #   interpretune (pyproject.toml:test)
     #   nbval
@@ -86,11 +86,11 @@ cryptography==46.0.3 ; platform_machine != 'ppc64le' and platform_machine != 's3
     # via secretstorage
 cycler==0.12.1
     # via matplotlib
-datasets==4.4.1
+datasets==4.4.2
     # via
     #   interpretune (pyproject.toml)
     #   evaluate
-debugpy==1.8.17
+debugpy==1.8.19
     # via ipykernel
 decorator==5.2.1
     # via ipython
@@ -105,7 +105,7 @@ distlib==0.4.0
     # via virtualenv
 docstring-parser==0.17.0
     # via jsonargparse
-docutils==0.22.3
+docutils==0.22.4
     # via readme-renderer
 entrypoints==0.4
     # via papermill
@@ -115,7 +115,7 @@ executing==2.2.1
     # via stack-data
 fastjsonschema==2.21.2
     # via nbformat
-filelock==3.20.0
+filelock==3.20.3
     # via
     #   datasets
     #   gdown
@@ -123,9 +123,7 @@ filelock==3.20.0
     #   torch
     #   transformers
     #   virtualenv
-finetuning-scheduler==2.9.1
-    # via interpretune (pyproject.toml)
-fonttools==4.60.1
+fonttools==4.61.1
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -138,14 +136,12 @@ fsspec[http]==2025.10.0
     #   datasets
     #   evaluate
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
     #   torch
 gdown==5.2.0
     # via interpretune (pyproject.toml)
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.45
+gitpython==3.1.46
     # via wandb
 grpcio==1.76.0
     # via tensorboard
@@ -188,7 +184,7 @@ ipykernel==7.1.0
     #   jupyterlab
     #   nbmake
     #   nbval
-ipython==9.7.0
+ipython==9.9.0
     # via
     #   ipykernel
     #   ipywidgets
@@ -200,9 +196,9 @@ isoduration==20.11.0
     # via jsonschema
 jaraco-classes==3.4.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via keyring
-jaraco-context==6.0.1 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
+jaraco-context==6.0.2 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via keyring
-jaraco-functools==4.3.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
+jaraco-functools==4.4.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via keyring
 jedi==0.19.2
     # via ipython
@@ -217,22 +213,22 @@ jinja2==3.1.6
     #   jupyterlab-server
     #   nbconvert
     #   torch
-joblib==1.5.2
+joblib==1.5.3
     # via scikit-learn
-json5==0.12.1
+json5==0.13.0
     # via jupyterlab-server
 jsonargparse[signatures]==4.41.0
     # via interpretune (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format-nongpl]==4.25.1
+jsonschema[format-nongpl]==4.26.0
     # via
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
 jsonschema-specifications==2025.9.1
     # via jsonschema
-jupyter-client==8.6.3
+jupyter-client==8.8.0
     # via
     #   ipykernel
     #   jupyter-server
@@ -260,7 +256,7 @@ jupyter-server==2.17.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.5.0
+jupyterlab==4.5.1
     # via
     #   interpretune (pyproject.toml)
     #   notebook
@@ -280,13 +276,6 @@ kiwisolver==1.4.9
     # via matplotlib
 lark==1.3.1
     # via rfc3987-syntax
-lightning==2.5.6
-    # via finetuning-scheduler
-lightning-utilities==0.15.2
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 markdown==3.10
     # via tensorboard
 markdown-it-py==4.0.0
@@ -299,7 +288,7 @@ markupsafe==3.0.3
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.10.7
+matplotlib==3.10.8
     # via interpretune (pyproject.toml)
 matplotlib-inline==0.2.1
     # via
@@ -309,7 +298,7 @@ mdit-py-plugins==0.5.0
     # via jupytext
 mdurl==0.1.2
     # via markdown-it-py
-mistune==3.1.4
+mistune==3.2.0
     # via nbconvert
 more-itertools==10.8.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via
@@ -325,9 +314,9 @@ multiprocess==0.70.18
     # via
     #   datasets
     #   evaluate
-narwhals==2.12.0
+narwhals==2.15.0
     # via plotly
-nbclient==0.10.2
+nbclient==0.10.4
     # via
     #   nbconvert
     #   nbmake
@@ -349,23 +338,23 @@ nbval==0.11.0
     # via interpretune (pyproject.toml)
 nest-asyncio==1.6.0
     # via ipykernel
-networkx==3.5
+networkx==3.6.1
     # via torch
 neuronpedia==1.2.0
     # via interpretune (pyproject.toml)
 nh3==0.3.2
     # via readme-renderer
-nodeenv==1.9.1
+nodeenv==1.10.0
     # via
     #   pre-commit
     #   pyright
-notebook==7.5.0
+notebook==7.5.1
     # via interpretune (pyproject.toml)
 notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numpy==2.3.5
+numpy==2.4.0
     # via
     #   accelerate
     #   bitsandbytes
@@ -378,7 +367,6 @@ numpy==2.3.5
     #   scikit-learn
     #   scipy
     #   tensorboard
-    #   torchmetrics
     #   transformers
 nvidia-cublas-cu12==12.8.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via
@@ -432,17 +420,13 @@ packaging==25.0
     #   jupyterlab
     #   jupyterlab-server
     #   jupytext
-    #   lightning
-    #   lightning-utilities
     #   matplotlib
     #   nbconvert
     #   peft
     #   plotly
     #   pytest
     #   pytest-rerunfailures
-    #   pytorch-lightning
     #   tensorboard
-    #   torchmetrics
     #   transformers
     #   twine
     #   wandb
@@ -457,24 +441,24 @@ papermill==2.6.0
     # via interpretune (pyproject.toml:test)
 parso==0.8.5
     # via jedi
-peft==0.18.0
+peft==0.18.1
     # via interpretune (pyproject.toml)
 pexpect==4.9.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
     # via ipython
-pillow==12.0.0
+pillow==12.1.0
     # via
     #   matplotlib
     #   tensorboard
-platformdirs==4.5.0
+platformdirs==4.5.1
     # via
     #   jupyter-core
     #   virtualenv
     #   wandb
-plotly==6.5.0
+plotly==6.5.1
     # via interpretune (pyproject.toml)
 pluggy==1.6.0
     # via pytest
-pre-commit==4.5.0
+pre-commit==4.5.1
     # via
     #   interpretune (pyproject.toml:dev)
     #   interpretune (pyproject.toml:test)
@@ -486,16 +470,16 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-protobuf==6.33.1
+protobuf==6.33.2
     # via
     #   tensorboard
     #   wandb
-psutil==7.1.3
+psutil==7.2.1
     # via
     #   accelerate
     #   ipykernel
     #   peft
-psycopg==3.2.13
+psycopg==3.3.2
     # via interpretune (pyproject.toml:test)
 ptyprocess==0.7.0 ; os_name != 'nt' or (sys_platform != 'emscripten' and sys_platform != 'win32')
     # via
@@ -509,7 +493,7 @@ pyarrow==22.0.0
     # via datasets
 pycparser==2.23 ; implementation_name != 'PyPy'
     # via cffi
-pydantic==2.12.4
+pydantic==2.12.5
     # via wandb
 pydantic-core==2.41.5
     # via pydantic
@@ -522,15 +506,15 @@ pygments==2.19.2
     #   pytest
     #   readme-renderer
     #   rich
-pyparsing==3.2.5
+pyparsing==3.3.1
     # via matplotlib
-pyright==1.1.407
+pyright==1.1.408
     # via
     #   interpretune (pyproject.toml:dev)
     #   interpretune (pyproject.toml:test)
 pysocks==1.7.1
     # via requests
-pytest==9.0.1
+pytest==9.0.2
     # via
     #   interpretune (pyproject.toml:test)
     #   nbmake
@@ -550,8 +534,6 @@ python-dotenv==1.2.1
     #   neuronpedia
 python-json-logger==4.0.0
     # via jupyter-events
-pytorch-lightning==2.5.6
-    # via lightning
 pytz==2025.2
     # via pandas
 pywin32-ctypes==0.2.3 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'win32'
@@ -569,11 +551,9 @@ pyyaml==6.0.3
     #   jsonargparse
     #   jupyter-events
     #   jupytext
-    #   lightning
     #   papermill
     #   peft
     #   pre-commit
-    #   pytorch-lightning
     #   transformers
     #   wandb
 pyzmq==27.1.0
@@ -620,7 +600,7 @@ rfc3987-syntax==1.1.0
     # via jsonschema
 rich==14.2.0
     # via twine
-rpds-py==0.29.0
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
@@ -629,20 +609,19 @@ safetensors==0.7.0
     #   accelerate
     #   peft
     #   transformers
-scikit-learn==1.7.2
+scikit-learn==1.8.0
     # via interpretune (pyproject.toml)
 scipy==1.16.3
     # via scikit-learn
 secretstorage==3.5.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via keyring
-send2trash==1.8.3
+send2trash==2.0.0
     # via jupyter-server
-sentry-sdk==2.45.0
+sentry-sdk==2.49.0
     # via wandb
 setuptools==80.9.0
     # via
     #   jupyterlab
-    #   lightning-utilities
     #   tensorboard
     #   torch
 six==1.17.0
@@ -651,9 +630,7 @@ six==1.17.0
     #   rfc3339-validator
 smmap==5.0.2
     # via gitdb
-sniffio==1.3.1
-    # via anyio
-soupsieve==2.8
+soupsieve==2.8.1
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
@@ -675,7 +652,7 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tinycss2==1.4.0
     # via bleach
-tokenizers==0.22.1
+tokenizers==0.22.2
     # via transformers
 toml==0.10.2
     # via
@@ -686,18 +663,10 @@ torch==2.9.1
     #   interpretune (pyproject.toml)
     #   accelerate
     #   bitsandbytes
-    #   finetuning-scheduler
-    #   lightning
     #   peft
-    #   pytorch-lightning
-    #   torchmetrics
 torch-tb-profiler==0.4.3
     # via interpretune (pyproject.toml)
-torchmetrics==1.8.2
-    # via
-    #   lightning
-    #   pytorch-lightning
-tornado==6.5.2
+tornado==6.5.4
     # via
     #   ipykernel
     #   jupyter-client
@@ -711,10 +680,8 @@ tqdm==4.67.1
     #   evaluate
     #   gdown
     #   huggingface-hub
-    #   lightning
     #   papermill
     #   peft
-    #   pytorch-lightning
     #   transformers
 traitlets==5.14.3
     # via
@@ -730,7 +697,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==4.57.1
+transformers==4.57.3
     # via
     #   interpretune (pyproject.toml)
     #   peft
@@ -747,13 +714,10 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   grpcio
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
     #   psycopg
     #   pydantic
     #   pydantic-core
     #   pyright
-    #   pytorch-lightning
     #   referencing
     #   torch
     #   typeshed-client
@@ -761,25 +725,25 @@ typing-extensions==4.15.0
     #   wandb
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   arrow
     #   pandas
     #   psycopg
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   requests
     #   sentry-sdk
     #   twine
-uv==0.9.11
+uv==0.9.22
     # via
     #   interpretune (pyproject.toml:dev)
     #   interpretune (pyproject.toml:test)
-virtualenv==20.35.4
+virtualenv==20.36.1
     # via pre-commit
-wandb==0.23.0
+wandb==0.23.1
     # via interpretune (pyproject.toml)
 wcwidth==0.2.14
     # via prompt-toolkit
@@ -791,7 +755,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.9.0
     # via jupyter-server
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via tensorboard
 widgetsnbextension==4.0.15
     # via ipywidgets

--- a/src/interpretune/adapters/model_view.py
+++ b/src/interpretune/adapters/model_view.py
@@ -1,0 +1,182 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parameter naming transformation strategies (ModelView) for fine-tuning schedules.
+
+A ModelView encapsulates a specific way of viewing/naming model parameters, enabling transformation between the view's
+naming convention and canonical PyTorch parameter names. This abstraction allows FTS schedules to use various naming
+conventions (e.g., TransformerLens-style, SAELens-style, custom architectures) while maintaining clean separation of
+concerns.
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+
+import torch
+
+from interpretune.utils import rank_zero_debug
+
+if TYPE_CHECKING:
+    from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+
+__all__ = ["ModelView", "CanonicalModelView"]
+
+
+class ModelView(ABC):
+    """Abstract base for parameter naming transformation strategies.
+
+    A ModelView encapsulates a specific way of viewing/naming model parameters,
+    enabling transformation between the view's naming convention and canonical
+    PyTorch parameter names.
+
+    Examples:
+        - TLNamesModelView: TransformerLens-style names (blocks.0.attn.W_Q)
+        - CanonicalView: Standard PyTorch names (model.transformer.h.0.attn.q.weight)
+        - Future: SAELensView, CustomArchitectureView, etc.
+
+    Args:
+        adapter: Parent StrategyAdapter instance for context access
+    """
+
+    def __init__(self, adapter: "StrategyAdapter"):
+        self.adapter = adapter
+        self.pl_module = adapter.pl_module
+        self.trainer = adapter.trainer
+
+    @abstractmethod
+    def build_param_mapping(self) -> None:
+        """Build bidirectional parameter name mappings.
+
+        Called once during FTS initialization to establish mappings between view-specific names and canonical parameter
+        names.
+        """
+        pass
+
+    @abstractmethod
+    def transform_to_canonical(self, param_names: List[str], inspect_only: bool = False) -> List[str]:
+        """Transform view-specific parameter names to canonical names.
+
+        Used by FTS to convert schedule params to optimizer params.
+
+        Args:
+            param_names: Parameters in view-specific naming
+            inspect_only: If True, only validate mapping without transforming
+
+        Returns:
+            Canonical parameter names for optimizer
+        """
+        pass
+
+    @abstractmethod
+    def transform_from_canonical(self, param_names: List[str]) -> List[str]:
+        """Transform canonical parameter names to view-specific names.
+
+        Used for logging/reporting optimizer params in view naming.
+
+        Args:
+            param_names: Canonical parameter names from optimizer
+
+        Returns:
+            View-specific parameter names
+        """
+        pass
+
+    @abstractmethod
+    def get_named_params(self) -> Dict[str, torch.Tensor]:
+        """Get model parameters using view-specific naming.
+
+        Returns:
+            Dict mapping view-specific names to parameter tensors
+        """
+        pass
+
+    @abstractmethod
+    def gen_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
+        """Generate implicit schedule using view-specific naming.
+
+        Args:
+            dump_loc: Directory to write schedule file
+
+        Returns:
+            Path to generated schedule YAML
+        """
+        pass
+
+    @abstractmethod
+    def validate_schedule(self) -> Tuple[int, int]:
+        """Validate schedule with optional view-specific diagnostics.
+
+        Delegates to base StrategyAdapter implementation.
+        Subclasses can override to add view-specific logging/checks.
+
+        Returns:
+            Tuple of (max_depth, max_epoch_watermark)
+        """
+        pass
+
+
+class CanonicalModelView(ModelView):
+    """Default canonical parameter naming (no transformation).
+
+    This view represents the identity transformation - parameters are
+    already in canonical PyTorch naming and no transformation is needed.
+    Used as the default when no specific view is requested.
+    """
+
+    def __init__(self, adapter: "StrategyAdapter", **kwargs):
+        """Initialize canonical model view.
+
+        Args:
+            adapter: The strategy adapter instance
+            **kwargs: Future configuration options (currently unused)
+        """
+        super().__init__(adapter)
+        if kwargs:
+            rank_zero_debug(f"CanonicalModelView received unused config: {kwargs}")
+
+    def build_param_mapping(self) -> None:
+        """No mapping needed for canonical naming."""
+        pass
+
+    def transform_to_canonical(self, param_names: List[str], inspect_only: bool = False) -> List[str]:
+        """Identity transformation - params already canonical."""
+        return param_names
+
+    def transform_from_canonical(self, param_names: List[str]) -> List[str]:
+        """Identity transformation - params already canonical."""
+        return param_names
+
+    def get_named_params(self) -> Dict[str, torch.Tensor]:
+        """Get canonical parameter names."""
+        return dict(self.pl_module.named_parameters())
+
+    def gen_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
+        """Generate schedule with canonical naming.
+
+        Delegates to base StrategyAdapter implementation via the adapter reference.
+        """
+        # Call the base StrategyAdapter.gen_ft_schedule() method through the adapter
+        from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+
+        return StrategyAdapter.gen_ft_schedule(self.adapter, dump_loc)
+
+    def validate_schedule(self) -> Tuple[int, int]:
+        """Validate schedule with canonical naming.
+
+        Delegates to base StrategyAdapter implementation via the adapter reference.
+        """
+        # Call the base StrategyAdapter.validate_ft_sched() method through the adapter
+        from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+
+        return StrategyAdapter.validate_ft_sched(self.adapter)

--- a/src/interpretune/adapters/sae_lens.py
+++ b/src/interpretune/adapters/sae_lens.py
@@ -122,12 +122,12 @@ class SAELensAdapter(SAELensAttributeMixin):
             and hasattr(self, "construct_names_filter")
         )
 
-    def _init_dirs_and_hooks(self) -> None:
+    def _make_setup_dirs(self) -> None:
         # Call the parent implementation to perform core directory and hook setup.
         # BaseITModule is always present in the composition hierarchy for SAE-enabled modules.
         # TODO: standardize and document how we handle these static type checker challenges. We currently use a mix of,
-        #       assertions, type checker directives and casting, e.g. cast(BaseITModule, self)._init_dirs_and_hooks()
-        super()._init_dirs_and_hooks()  # type: ignore[attr-defined]
+        #       assertions, type checker directives and casting, e.g. cast(BaseITModule, self)._make_setup_dirs()
+        super()._make_setup_dirs()  # type: ignore[attr-defined]
 
         # SAE-specific analysis initialization: only run when the light-weight structural checks pass
         if self.has_sae_analysis_cfg:

--- a/src/interpretune/adapters/transformer_lens.py
+++ b/src/interpretune/adapters/transformer_lens.py
@@ -258,25 +258,6 @@ class BaseITLensModule(BaseITModule):
 
         # Create adapter and bridge
         adapter = ArchitectureAdapterFactory.select_architecture_adapter(bridge_config)
-
-        # Inspect HF model before TransformerBridge instantiation
-        inspect_state_dict_or_params(
-            hf_model.state_dict(),
-            "hf_model.state_dict()",
-            context_message="Before TransformerBridge instantiation",
-            prefix_filter=None,
-            num_keys_sample=10,
-            log_debug=True,
-        )
-        inspect_state_dict_or_params(
-            hf_model,
-            "hf_model.named_parameters()",
-            context_message="Before TransformerBridge instantiation",
-            prefix_filter=None,
-            num_keys_sample=10,
-            log_debug=True,
-        )
-
         self.model = TransformerBridge(model=hf_model, adapter=adapter, tokenizer=tokenizer_handle)
 
         # Debug shim: log component mapping for troubleshooting checkpoint restoration
@@ -291,32 +272,6 @@ class BaseITLensModule(BaseITModule):
             compat_kwargs = self.it_cfg.tl_cfg.enable_compatibility_mode_kwargs or {}
             rank_zero_info(f"Enabling TransformerBridge compatibility mode with kwargs: {compat_kwargs}")
             self.model.enable_compatibility_mode(**compat_kwargs)
-
-        # Inspect TransformerBridge after instantiation
-        inspect_state_dict_or_params(
-            self.model,
-            "self.model.named_parameters()",
-            context_message="After TransformerBridge instantiation",
-            prefix_filter="",
-            num_keys_sample=10,
-            log_debug=True,
-        )
-        inspect_state_dict_or_params(
-            self.model,
-            "self.model.tl_named_parameters()",
-            context_message="After TransformerBridge instantiation",
-            prefix_filter="",
-            num_keys_sample=10,
-            log_debug=True,
-        )
-        inspect_state_dict_or_params(
-            self.model.state_dict(),
-            "self.model.state_dict()",
-            context_message="After TransformerBridge instantiation",
-            prefix_filter="",
-            num_keys_sample=10,
-            log_debug=True,
-        )
 
         # Move model to device if move_to_device is enabled (default True)
         if pruned_cfg.get("move_to_device", True) and "device" in pruned_cfg:
@@ -418,189 +373,6 @@ class ITLensModule(TransformerLensAdapter, CoreHelperAttributes, BaseITLensModul
 if _FTS_AVAILABLE:
     from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
 
-    def inspect_state_dict_or_params(
-        source: Union[Dict[str, Any], Any],
-        source_name: str = "state_dict",
-        context_message: Optional[str] = None,
-        prefix_filter: Optional[str] = "model.",
-        num_keys_sample: int = 10,
-        log_debug: bool = False,
-        return_string: bool = False,
-    ) -> Optional[str]:
-        """Inspect and pretty-print state_dict or named_parameters for debugging checkpoint flows.
-
-        This is a standalone debugging utility that can be used at any point in the checkpoint
-        save/load pipeline to inspect the structure, types, shapes, and devices of model parameters.
-
-        Args:
-            source: Either a state_dict (dict) or an object with named_parameters() method
-            source_name: Descriptive name for the source being inspected
-            context_message: Optional context message to display before inspection output
-            prefix_filter: Only include keys starting with this prefix (None = no filtering)
-            num_keys_sample: Number of first/last keys to display in summary
-            log_debug: If True, also log output at DEBUG level
-            return_string: If True, return the formatted string instead of printing
-
-        Returns:
-            Formatted string if return_string=True, "data collection error" on failure, otherwise None
-
-        Example:
-            >>> # Inspect a model's state_dict
-            >>> inspect_state_dict_or_params(
-            ...     model.state_dict(),
-            ...     "model.state_dict()",
-            ...     context_message="Before checkpoint save"
-            ... )
-            >>>
-            >>> # Inspect named_parameters iterator with requires_grad count
-            >>> inspect_state_dict_or_params(
-            ...     model,
-            ...     "model.named_parameters()",
-            ...     context_message="After TransformerBridge instantiation"
-            ... )
-        """
-        from pprint import pformat
-
-        try:
-            # Convert source to dict format
-            is_named_params = False
-            requires_grad_count = None
-
-            if isinstance(source, dict):
-                state_dict = source
-            elif hasattr(source, "named_parameters") or hasattr(source, "tl_named_parameters"):
-                # Prefer tl_named_parameters when explicitly requested via source_name
-                prefer_tl = "tl_named_parameters" in (source_name or "")
-                prefer_named = "named_parameters" in (source_name or "")
-                # Choose the appropriate iterator when available
-                if hasattr(source, "tl_named_parameters") and (
-                    prefer_tl or (not prefer_named and not hasattr(source, "named_parameters"))
-                ):
-                    is_named_params = True
-                    params_list = list(source.tl_named_parameters())
-                elif hasattr(source, "named_parameters"):
-                    is_named_params = True
-                    params_list = list(source.named_parameters())
-                else:
-                    # Fall back defensively
-                    rank_zero_warn(
-                        f"inspect_state_dict_or_params: Source has no named parameter iterators, got {type(source)}"
-                    )
-                    return "data collection error"
-                state_dict = dict(params_list)
-                requires_grad_count = sum(1 for _, p in params_list if hasattr(p, "requires_grad") and p.requires_grad)
-            else:
-                rank_zero_warn(
-                    f"inspect_state_dict_or_params: Source must be a dict or have named_parameters() method, "
-                    f"got {type(source)}"
-                )
-                return "data collection error"
-
-            # Apply prefix filter if specified
-            if prefix_filter is not None:
-                filtered_dict = {k: v for k, v in state_dict.items() if k.startswith(prefix_filter)}
-            else:
-                filtered_dict = state_dict
-
-            # Collect metadata
-            num_keys = len(filtered_dict)
-            keys_list = list(filtered_dict.keys())
-
-            # Analyze each value
-            value_metadata = []
-            for key, value in filtered_dict.items():
-                meta = {
-                    "key": key,
-                    "type": type(value).__name__,
-                    "shape": tuple(value.shape) if hasattr(value, "shape") else None,
-                    "device": str(value.device) if hasattr(value, "device") else None,
-                    "dtype": str(value.dtype) if hasattr(value, "dtype") else None,
-                }
-                value_metadata.append(meta)
-
-            # Build output string
-            lines = []
-            lines.append("=" * 80)
-            lines.append(f"STATE INSPECTION: {source_name}")
-            if context_message:
-                lines.append(f"Context: {context_message}")
-            lines.append("=" * 80)
-            lines.append(f"Prefix filter: {prefix_filter if prefix_filter else 'None (all keys)'}")
-            lines.append(f"Total keys: {num_keys}")
-            if is_named_params and requires_grad_count is not None:
-                lines.append(f"Parameters with requires_grad=True: {requires_grad_count}")
-            lines.append("")
-
-            # Sample of first/last keys
-            lines.append(f"First {min(num_keys_sample, num_keys)} keys:")
-            for key in keys_list[:num_keys_sample]:
-                lines.append(f"  {key}")
-            lines.append("")
-
-            if num_keys > num_keys_sample * 2:
-                lines.append(f"Last {min(num_keys_sample, num_keys)} keys:")
-                for key in keys_list[-num_keys_sample:]:
-                    lines.append(f"  {key}")
-                lines.append("")
-
-            # Metadata summary
-            lines.append("Value metadata summary (first 10):")
-            for meta in value_metadata[:10]:
-                lines.append(f"  {meta['key']}:")
-                lines.append(f"    type: {meta['type']}")
-                if meta["shape"] is not None:
-                    lines.append(f"    shape: {meta['shape']}")
-                if meta["device"] is not None:
-                    lines.append(f"    device: {meta['device']}")
-                if meta["dtype"] is not None:
-                    lines.append(f"    dtype: {meta['dtype']}")
-            lines.append("")
-
-            # Type/shape distribution
-            type_counts = {}
-            shape_counts = {}
-            device_counts = {}
-            for meta in value_metadata:
-                type_counts[meta["type"]] = type_counts.get(meta["type"], 0) + 1
-                if meta["shape"] is not None:
-                    shape_counts[meta["shape"]] = shape_counts.get(meta["shape"], 0) + 1
-                if meta["device"] is not None:
-                    device_counts[meta["device"]] = device_counts.get(meta["device"], 0) + 1
-
-            lines.append("Type distribution:")
-            lines.append(pformat(type_counts, indent=2))
-            lines.append("")
-
-            if shape_counts:
-                lines.append("Shape distribution (top 10):")
-                sorted_shapes = sorted(shape_counts.items(), key=lambda x: x[1], reverse=True)[:10]
-                lines.append(pformat(dict(sorted_shapes), indent=2))
-                lines.append("")
-
-            if device_counts:
-                lines.append("Device distribution:")
-                lines.append(pformat(device_counts, indent=2))
-                lines.append("")
-
-            lines.append("=" * 80)
-
-            output = "\n".join(lines)
-
-            # Output handling
-            if log_debug:
-                rank_zero_debug(f"\n{output}")
-
-            if return_string:
-                return output
-            else:
-                print(output)
-                return None
-
-        except Exception as e:
-            error_msg = f"inspect_state_dict_or_params error for {source_name}: {e}"
-            rank_zero_warn(error_msg)
-            return "data collection error"
-
     # TODO: will need to gate this on Lightning being available as well once FTS can use raw torch
     # Strategy adapter for TransformerLens Bridge integration
     class TransformerBridgeStrategyAdapter(StrategyAdapter):
@@ -624,9 +396,6 @@ if _FTS_AVAILABLE:
             use_tl_names: Convenience flag. If True, automatically creates TLNamesModelView instance.
                 Cannot be used together with model_view parameter.
         """
-
-        # Attach standalone debugging utility as static method
-        inspect_state = staticmethod(inspect_state_dict_or_params)
 
         def __init__(
             self,
@@ -697,15 +466,6 @@ if _FTS_AVAILABLE:
 
             # Ensure model_view is initialized (may already be initialized if gen_ft_sched_only=True)
             self._ensure_model_view_initialized()
-
-        def on_before_restore_optimizers_and_lrs(self) -> None:
-            """Allow inspection for now.
-
-            May be necessary so we can allow adapter to manage the movement of restored optimizer states to the relevant
-            devices.
-            """
-            checkpoint_connector = self.trainer._checkpoint_connector
-            _ = checkpoint_connector._loaded_checkpoint["optimizer_states"]
 
         def fts_optim_transform(self, orig_pl: List[str], inspect_only: bool = False) -> List[str]:
             """Transform parameter names to canonical names for optimizer.

--- a/src/interpretune/adapters/transformer_lens.py
+++ b/src/interpretune/adapters/transformer_lens.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Type, cast, Union, Dict, Any, List
+from typing import Optional, Type, cast, Union, Dict, Any, List, Mapping
 import inspect
 from functools import reduce, partial
 from copy import deepcopy
@@ -236,16 +236,25 @@ class BaseITLensModule(BaseITModule):
 
         # Create adapter and bridge
         adapter = ArchitectureAdapterFactory.select_architecture_adapter(bridge_config)
-        ### TMP DEBUG SHIM START ###
-        rank_zero_debug("=== BRIDGE CONVERSION DEBUG ===")
 
-        # 1. Capture HF model state dict
-        hf_state_dict = hf_model.state_dict()
-        hf_keys_sample = list(hf_state_dict.keys())[:10]
-        rank_zero_debug(f"HF model state_dict keys (sample): {hf_keys_sample}")
+        # Inspect HF model before TransformerBridge instantiation
+        inspect_state_dict_or_params(
+            hf_model.state_dict(),
+            "hf_model.state_dict()",
+            context_message="Before TransformerBridge instantiation",
+            prefix_filter=None,
+            num_keys_sample=10,
+            log_debug=True,
+        )
+        inspect_state_dict_or_params(
+            hf_model,
+            "hf_model.named_parameters()",
+            context_message="Before TransformerBridge instantiation",
+            prefix_filter=None,
+            num_keys_sample=10,
+            log_debug=True,
+        )
 
-        # 2. Create Bridge
-        ### TMP DEBUG SHIM END ###
         self.model = TransformerBridge(model=hf_model, adapter=adapter, tokenizer=tokenizer_handle)
 
         # Debug shim: log component mapping for troubleshooting checkpoint restoration
@@ -255,22 +264,32 @@ class BaseITLensModule(BaseITModule):
             rank_zero_debug(f"TransformerBridge component_mapping keys: {list(component_mapping.keys())}")
             rank_zero_debug(f"TransformerBridge HF top-level prefixes: {hf_prefixes}")
 
-        ### TMP DEBUG SHIM START ###
-        # 3. Capture Bridge model state dict (default - should return TL style keys)
-        bridge_state_dict = self.model.state_dict()
-        bridge_keys_sample = list(bridge_state_dict.keys())[:10]
-        rank_zero_debug(f"Bridge model.state_dict() keys (sample): {bridge_keys_sample}")
+        # Inspect TransformerBridge after instantiation
+        inspect_state_dict_or_params(
+            self.model,
+            "self.model.named_parameters()",
+            context_message="After TransformerBridge instantiation",
+            prefix_filter="",
+            num_keys_sample=10,
+            log_debug=True,
+        )
+        inspect_state_dict_or_params(
+            self.model,
+            "self.model.tl_named_parameters()",
+            context_message="After TransformerBridge instantiation",
+            prefix_filter="",
+            num_keys_sample=10,
+            log_debug=True,
+        )
+        inspect_state_dict_or_params(
+            self.model.state_dict(),
+            "self.model.state_dict()",
+            context_message="After TransformerBridge instantiation",
+            prefix_filter="",
+            num_keys_sample=10,
+            log_debug=True,
+        )
 
-        # 4. Capture Bridge TL-style state dict (if different)
-        tl_params = {n: p.shape for n, p in self.model.tl_named_parameters()}
-        tl_keys_sample = list(tl_params.keys())[:10]
-        rank_zero_debug(f"Bridge tl_named_parameters() keys (sample): {tl_keys_sample}")
-
-        # 5. Capture Bridge runtime parameters (named_parameters - what optimizer sees)
-        runtime_params = {n: p.shape for n, p in self.model.named_parameters()}
-        runtime_keys_sample = list(runtime_params.keys())[:10]
-        rank_zero_debug(f"Bridge named_parameters() keys (sample): {runtime_keys_sample}")
-        ### TMP DEBUG SHIM END ###
         # Move model to device if move_to_device is enabled (default True)
         if pruned_cfg.get("move_to_device", True) and "device" in pruned_cfg:
             device = pruned_cfg["device"]
@@ -371,6 +390,190 @@ class ITLensModule(TransformerLensAdapter, CoreHelperAttributes, BaseITLensModul
 if _FTS_AVAILABLE:
     from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
 
+    def inspect_state_dict_or_params(
+        source: Union[Dict[str, Any], Any],
+        source_name: str = "state_dict",
+        context_message: Optional[str] = None,
+        prefix_filter: Optional[str] = "model.",
+        num_keys_sample: int = 10,
+        log_debug: bool = False,
+        return_string: bool = False,
+    ) -> Optional[str]:
+        """Inspect and pretty-print state_dict or named_parameters for debugging checkpoint flows.
+
+        This is a standalone debugging utility that can be used at any point in the checkpoint
+        save/load pipeline to inspect the structure, types, shapes, and devices of model parameters.
+
+        Args:
+            source: Either a state_dict (dict) or an object with named_parameters() method
+            source_name: Descriptive name for the source being inspected
+            context_message: Optional context message to display before inspection output
+            prefix_filter: Only include keys starting with this prefix (None = no filtering)
+            num_keys_sample: Number of first/last keys to display in summary
+            log_debug: If True, also log output at DEBUG level
+            return_string: If True, return the formatted string instead of printing
+
+        Returns:
+            Formatted string if return_string=True, "data collection error" on failure, otherwise None
+
+        Example:
+            >>> # Inspect a model's state_dict
+            >>> inspect_state_dict_or_params(
+            ...     model.state_dict(),
+            ...     "model.state_dict()",
+            ...     context_message="Before checkpoint save"
+            ... )
+            >>>
+            >>> # Inspect named_parameters iterator with requires_grad count
+            >>> inspect_state_dict_or_params(
+            ...     model,
+            ...     "model.named_parameters()",
+            ...     context_message="After TransformerBridge instantiation"
+            ... )
+        """
+        from pprint import pformat
+
+        try:
+            # Convert source to dict format
+            is_named_params = False
+            requires_grad_count = None
+
+            if isinstance(source, dict):
+                state_dict = source
+            elif hasattr(source, "named_parameters") or hasattr(source, "tl_named_parameters"):
+                # Prefer tl_named_parameters when explicitly requested via source_name
+                prefer_tl = "tl_named_parameters" in (source_name or "")
+                prefer_named = "named_parameters" in (source_name or "")
+                # Choose the appropriate iterator when available
+                if hasattr(source, "tl_named_parameters") and (
+                    prefer_tl or (not prefer_named and not hasattr(source, "named_parameters"))
+                ):
+                    is_named_params = True
+                    params_list = list(source.tl_named_parameters())
+                elif hasattr(source, "named_parameters"):
+                    is_named_params = True
+                    params_list = list(source.named_parameters())
+                else:
+                    # Fall back defensively
+                    rank_zero_warn(
+                        f"inspect_state_dict_or_params: Source has no named parameter iterators, got {type(source)}"
+                    )
+                    return "data collection error"
+                state_dict = dict(params_list)
+                requires_grad_count = sum(1 for _, p in params_list if hasattr(p, "requires_grad") and p.requires_grad)
+            else:
+                rank_zero_warn(
+                    f"inspect_state_dict_or_params: Source must be a dict or have named_parameters() method, "
+                    f"got {type(source)}"
+                )
+                return "data collection error"
+
+            # Apply prefix filter if specified
+            if prefix_filter is not None:
+                filtered_dict = {k: v for k, v in state_dict.items() if k.startswith(prefix_filter)}
+            else:
+                filtered_dict = state_dict
+
+            # Collect metadata
+            num_keys = len(filtered_dict)
+            keys_list = list(filtered_dict.keys())
+
+            # Analyze each value
+            value_metadata = []
+            for key, value in filtered_dict.items():
+                meta = {
+                    "key": key,
+                    "type": type(value).__name__,
+                    "shape": tuple(value.shape) if hasattr(value, "shape") else None,
+                    "device": str(value.device) if hasattr(value, "device") else None,
+                    "dtype": str(value.dtype) if hasattr(value, "dtype") else None,
+                }
+                value_metadata.append(meta)
+
+            # Build output string
+            lines = []
+            lines.append("=" * 80)
+            lines.append(f"STATE INSPECTION: {source_name}")
+            if context_message:
+                lines.append(f"Context: {context_message}")
+            lines.append("=" * 80)
+            lines.append(f"Prefix filter: {prefix_filter if prefix_filter else 'None (all keys)'}")
+            lines.append(f"Total keys: {num_keys}")
+            if is_named_params and requires_grad_count is not None:
+                lines.append(f"Parameters with requires_grad=True: {requires_grad_count}")
+            lines.append("")
+
+            # Sample of first/last keys
+            lines.append(f"First {min(num_keys_sample, num_keys)} keys:")
+            for key in keys_list[:num_keys_sample]:
+                lines.append(f"  {key}")
+            lines.append("")
+
+            if num_keys > num_keys_sample * 2:
+                lines.append(f"Last {min(num_keys_sample, num_keys)} keys:")
+                for key in keys_list[-num_keys_sample:]:
+                    lines.append(f"  {key}")
+                lines.append("")
+
+            # Metadata summary
+            lines.append("Value metadata summary (first 10):")
+            for meta in value_metadata[:10]:
+                lines.append(f"  {meta['key']}:")
+                lines.append(f"    type: {meta['type']}")
+                if meta["shape"] is not None:
+                    lines.append(f"    shape: {meta['shape']}")
+                if meta["device"] is not None:
+                    lines.append(f"    device: {meta['device']}")
+                if meta["dtype"] is not None:
+                    lines.append(f"    dtype: {meta['dtype']}")
+            lines.append("")
+
+            # Type/shape distribution
+            type_counts = {}
+            shape_counts = {}
+            device_counts = {}
+            for meta in value_metadata:
+                type_counts[meta["type"]] = type_counts.get(meta["type"], 0) + 1
+                if meta["shape"] is not None:
+                    shape_counts[meta["shape"]] = shape_counts.get(meta["shape"], 0) + 1
+                if meta["device"] is not None:
+                    device_counts[meta["device"]] = device_counts.get(meta["device"], 0) + 1
+
+            lines.append("Type distribution:")
+            lines.append(pformat(type_counts, indent=2))
+            lines.append("")
+
+            if shape_counts:
+                lines.append("Shape distribution (top 10):")
+                sorted_shapes = sorted(shape_counts.items(), key=lambda x: x[1], reverse=True)[:10]
+                lines.append(pformat(dict(sorted_shapes), indent=2))
+                lines.append("")
+
+            if device_counts:
+                lines.append("Device distribution:")
+                lines.append(pformat(device_counts, indent=2))
+                lines.append("")
+
+            lines.append("=" * 80)
+
+            output = "\n".join(lines)
+
+            # Output handling
+            if log_debug:
+                rank_zero_debug(f"\n{output}")
+
+            if return_string:
+                return output
+            else:
+                print(output)
+                return None
+
+        except Exception as e:
+            error_msg = f"inspect_state_dict_or_params error for {source_name}: {e}"
+            rank_zero_warn(error_msg)
+            return "data collection error"
+
+    # TODO: will need to gate this on Lightning being available as well once FTS can use raw torch
     # Strategy adapter for TransformerLens Bridge integration
     class TransformerBridgeStrategyAdapter(StrategyAdapter):
         """Strategy adapter to support TransformerLens Bridge naming translation.
@@ -382,11 +585,18 @@ if _FTS_AVAILABLE:
         Uses the TransformerBridge adapter's component_mapping for architecture-agnostic conversion.
         """
 
+        # Attach standalone debugging utility as static method
+        inspect_state = staticmethod(inspect_state_dict_or_params)
+
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
             self.exec_ft_phase = partial(StrategyAdapter.base_ft_phase, translation_func=self.logical_param_translation)
-            self._component_mapping_cache: Optional[Dict[str, str]] = None
-            self._hf_top_level_prefixes_cache: Optional[set] = None
+
+        def on_before_init_fts(self) -> None:
+            # we patch our wrapped TransformerBridge module to use the TransformerBridge's state_dict and
+            # load_state_dict methods to handle the specialized key translation logic
+            setattr(self.pl_module, "state_dict", self.pl_module.model.state_dict)
+            setattr(self.pl_module, "load_state_dict", self.pl_module.model.load_state_dict)
 
         def logical_param_translation(self, param_names: List[str]) -> List[str]:
             return param_names
@@ -394,185 +604,18 @@ if _FTS_AVAILABLE:
         def fts_optim_transform(self, orig_pl: List[str], inspect_only: bool = False) -> List[str]:
             return orig_pl
 
-        def _get_bridge_adapter(self) -> Optional[Any]:
-            """Get the TransformerBridge adapter from the pl_module if available."""
-            try:
-                model = getattr(self.pl_module, "model", None)
-                if model is not None and hasattr(model, "adapter"):
-                    return model.adapter
-            except Exception:
-                pass
-            return None
-
-        def _build_prefix_mapping(self, adapter: Any) -> Dict[str, str]:
-            """Build HF->TL prefix mapping from the adapter's component_mapping.
-
-            Returns a dict mapping HF prefixes to TL prefixes, e.g.: {     'transformer.wte': 'embed',
-            'transformer.wpe': 'pos_embed',     'transformer.h': 'blocks',     'transformer.ln_f': 'ln_final',
-            'lm_head': 'unembed', }
-
-            Also populates self._hf_top_level_prefixes_cache with unique top-level HF prefixes (e.g., {'transformer',
-            'lm_head'} for GPT-2, {'model', 'lm_head'} for Llama).
-            """
-            if self._component_mapping_cache is not None:
-                return self._component_mapping_cache
-
-            mapping: Dict[str, str] = {}
-            hf_top_level_prefixes: set = set()
-            component_mapping = getattr(adapter, "component_mapping", None)
-            if component_mapping is None:
-                self._hf_top_level_prefixes_cache = hf_top_level_prefixes
-                return mapping
-
-            for tl_name, component in component_mapping.items():
-                hf_path = getattr(component, "name", None)
-                if hf_path is not None:
-                    mapping[hf_path] = tl_name
-                    # Extract top-level prefix (first component of the path)
-                    top_level = hf_path.split(".")[0]
-                    hf_top_level_prefixes.add(top_level)
-
-            self._component_mapping_cache = mapping
-            self._hf_top_level_prefixes_cache = hf_top_level_prefixes
-            return mapping
-
-        def _convert_checkpoint_key_to_runtime(self, ckpt_key: str, prefix_mapping: Dict[str, str]) -> str:
-            """Convert a checkpoint key (HF-style prefix) to runtime key (TL-style prefix).
-
-            Checkpoint: model.transformer.h.0._original_component.attn.q._original_component.weight
-            Runtime:    model.blocks.0._original_component.attn.q._original_component.weight
-
-            Only converts the top-level prefix path. Everything after the first _original_component
-            stays the same since those use TL-style submodule names already.
-            """
-            if not ckpt_key.startswith("model."):
-                return ckpt_key
-
-            key = ckpt_key[6:]  # Remove 'model.' prefix
-            oc_marker = "._original_component"
-
-            # Find the first _original_component - everything before it is the HF prefix to convert
-            first_oc_idx = key.find(oc_marker)
-            if first_oc_idx == -1:
-                # No _original_component - shouldn't happen for bridge keys, return as-is
-                return ckpt_key
-
-            hf_prefix = key[:first_oc_idx]
-            rest = key[first_oc_idx:]  # includes the _original_component
-
-            # Convert HF prefix to TL prefix using mapping
-            tl_prefix = hf_prefix  # default: keep as-is
-
-            # Check for blocks pattern: e.g. transformer.h.N -> blocks.N
-            blocks_hf_prefix = None
-            for hf_path, tl_name in prefix_mapping.items():
-                if tl_name == "blocks":
-                    blocks_hf_prefix = hf_path
-                    break
-
-            if blocks_hf_prefix and hf_prefix.startswith(blocks_hf_prefix + "."):
-                layer_part = hf_prefix[len(blocks_hf_prefix) + 1 :]
-                tl_prefix = f"blocks.{layer_part}"
-            else:
-                # Check other top-level components (exact match)
-                for hf_path, tl_name in prefix_mapping.items():
-                    if hf_prefix == hf_path:
-                        tl_prefix = tl_name
-                        break
-
-            return "model." + tl_prefix + rest
-
-        def before_restore_model(self, checkpoint: Dict[str, Any]) -> Dict[str, Any]:
-            """Prepare checkpoint for TransformerBridge restoration.
-
-            TransformerBridge creates multiple parameter aliases:
-            1. Original HF keys in checkpoint: model.transformer.*
-            2. TL-style aliases at runtime: model.embed.*, model.blocks.*, etc.
-            3. Prefixed HF keys at runtime: model.original_model.transformer.*
-
-            Checkpoints contain HF-style keys. We need to transform them to match
-            the runtime module structure:
-            - Add model.original_model.* prefix for HF keys
-            - Add TL-style aliases using adapter component mapping
-
-            Uses the bridge adapter's component_mapping for architecture-agnostic conversion.
-            """
-            state_dict = checkpoint.get("state_dict", {})
-            if not state_dict:
-                return checkpoint
-
-            # Get the bridge adapter for component mapping
-            adapter = self._get_bridge_adapter()
-            if adapter is None:
-                rank_zero_warn(
-                    "TransformerBridgeStrategyAdapter: Could not access bridge adapter. "
-                    "Skipping checkpoint key conversion."
-                )
-                return checkpoint
-
-            prefix_mapping = self._build_prefix_mapping(adapter)
-            if not prefix_mapping:
-                rank_zero_warn(
-                    "TransformerBridgeStrategyAdapter: No component mapping found. Skipping checkpoint key conversion."
-                )
-                return checkpoint
-
-            rank_zero_info(
-                "TransformerBridgeStrategyAdapter: Expanding checkpoint keys for TransformerBridge aliases..."
+        def lightning_module_state_dict(self) -> dict[str, Any]:
+            """Override lightning_module_state_dict to use TransformerBridge state_dict to avoid dup keys."""
+            assert (
+                self.pl_module is not None
+                and hasattr(self.pl_module, "model")
+                and hasattr(self.pl_module.model, "state_dict")
             )
-            rank_zero_debug(f"TransformerBridgeStrategyAdapter: Prefix mapping: {prefix_mapping}")
+            return self.pl_module.model.state_dict()
 
-            # Get HF top-level prefixes for architecture-agnostic original_model prefixing
-            hf_top_level_prefixes = self._hf_top_level_prefixes_cache or set()
-            rank_zero_debug(f"TransformerBridgeStrategyAdapter: HF top-level prefixes: {hf_top_level_prefixes}")
-
-            expanded_state_dict = {}
-            sample_conversions = []
-            sample_original_model_keys = []
-
-            for key, value in state_dict.items():
-                if not key.startswith("model."):
-                    # Non-model keys (optimizer states, etc.) pass through unchanged
-                    expanded_state_dict[key] = value
-                    continue
-
-                # Extract the component after "model." prefix to check against HF prefixes
-                key_after_model = key[6:]  # Remove "model." prefix
-                matched_hf_prefix = None
-                for hf_prefix in hf_top_level_prefixes:
-                    if key_after_model.startswith(hf_prefix + ".") or key_after_model == hf_prefix:
-                        matched_hf_prefix = hf_prefix
-                        break
-
-                if matched_hf_prefix:
-                    # Add original_model prefix for HF keys (required by runtime module structure)
-                    original_model_key = f"model.original_model.{key_after_model}"
-                    expanded_state_dict[original_model_key] = value
-                    if len(sample_original_model_keys) < 3:
-                        sample_original_model_keys.append(f"{key} -> {original_model_key}")
-                else:
-                    # Non-HF model keys - keep as-is
-                    expanded_state_dict[key] = value
-
-                # Add TL-style alias key using component mapping
-                tl_key = self._convert_checkpoint_key_to_runtime(key, prefix_mapping)
-                if tl_key != key:
-                    expanded_state_dict[tl_key] = value
-                    if len(sample_conversions) < 5:
-                        sample_conversions.append(f"{key} -> {tl_key}")
-
-            checkpoint["state_dict"] = expanded_state_dict
-            rank_zero_info(
-                f"TransformerBridgeStrategyAdapter: Expanded {len(state_dict)} keys to {len(expanded_state_dict)} keys"
-            )
-            if sample_original_model_keys:
-                rank_zero_debug(
-                    f"TransformerBridgeStrategyAdapter: Sample original_model prefixing: {sample_original_model_keys}"
-                )
-            if sample_conversions:
-                rank_zero_debug(f"TransformerBridgeStrategyAdapter: Sample TL conversions: {sample_conversions}")
-
-            return checkpoint
+        def load_model_state_dict(self, checkpoint: Mapping[str, Any], strict: bool = True) -> None:
+            assert self.pl_module is not None
+            self.pl_module.model.load_state_dict(checkpoint["state_dict"], strict=strict)
 
 else:
     TransformerBridgeStrategyAdapter = object

--- a/src/interpretune/adapters/transformer_lens.py
+++ b/src/interpretune/adapters/transformer_lens.py
@@ -1,5 +1,6 @@
 import os
-from typing import Optional, Type, cast, Union, Dict, Any, List, Mapping
+import re
+from typing import Optional, Type, cast, Union, Dict, Any, List, Mapping, Tuple
 import inspect
 from functools import reduce, partial
 from copy import deepcopy
@@ -18,7 +19,9 @@ from transformer_lens.model_bridge.sources.transformers import (
 from transformers.tokenization_utils_base import BatchEncoding
 
 from interpretune.adapters import CompositionRegistry, LightningDataModule, LightningModule, LightningAdapter
+from interpretune.adapters.model_view import ModelView, CanonicalModelView
 from interpretune.base import CoreHelperAttributes, ITDataModule, BaseITModule
+from interpretune.base.components.mixins import _import_class
 from interpretune.utils import move_data_to_device, rank_zero_warn, rank_zero_info, rank_zero_debug, _FTS_AVAILABLE
 from interpretune.protocol import Adapter
 
@@ -212,7 +215,13 @@ class BaseITLensModule(BaseITModule):
 
         TransformerBridge wraps the HF model without weight conversion, providing memory efficiency and better HF
         ecosystem compatibility.
+
+        If the tl_cfg is an ITLensBridgeConfig, this method will:
+        - Apply any transformer_bridge_config_overrides to the TransformerBridgeConfig
+        - Call enable_compatibility_mode() with the specified kwargs if enable_compatibility_mode=True
         """
+        from interpretune.config.transformer_lens import ITLensBridgeConfig
+
         tokenizer_handle = self.datamodule.tokenizer if self.datamodule else self.it_cfg.tokenizer
         hf_model = self.model
         hf_preconversion_config = deepcopy(hf_model.config)  # capture original hf config before conversion
@@ -233,6 +242,19 @@ class BaseITLensModule(BaseITModule):
             bridge_config.device = pruned_cfg["device"]
         if "dtype" in pruned_cfg:
             bridge_config.dtype = pruned_cfg["dtype"]
+
+        # Apply ITLensBridgeConfig-specific overrides if using that config type
+        if isinstance(self.it_cfg.tl_cfg, ITLensBridgeConfig):
+            if self.it_cfg.tl_cfg.transformer_bridge_config_overrides:
+                for key, value in self.it_cfg.tl_cfg.transformer_bridge_config_overrides.items():
+                    if hasattr(bridge_config, key):
+                        setattr(bridge_config, key, value)
+                        rank_zero_debug(f"Applied TransformerBridgeConfig override: {key}={value}")
+                    else:
+                        rank_zero_warn(
+                            f"transformer_bridge_config_overrides key '{key}' not found in "
+                            f"TransformerBridgeConfig, ignoring."
+                        )
 
         # Create adapter and bridge
         adapter = ArchitectureAdapterFactory.select_architecture_adapter(bridge_config)
@@ -263,6 +285,12 @@ class BaseITLensModule(BaseITModule):
             hf_prefixes = {getattr(c, "name", "?").split(".")[0] for c in component_mapping.values()}
             rank_zero_debug(f"TransformerBridge component_mapping keys: {list(component_mapping.keys())}")
             rank_zero_debug(f"TransformerBridge HF top-level prefixes: {hf_prefixes}")
+
+        # Enable compatibility mode if requested (ITLensBridgeConfig only)
+        if isinstance(self.it_cfg.tl_cfg, ITLensBridgeConfig) and self.it_cfg.tl_cfg.enable_compatibility_mode:
+            compat_kwargs = self.it_cfg.tl_cfg.enable_compatibility_mode_kwargs or {}
+            rank_zero_info(f"Enabling TransformerBridge compatibility mode with kwargs: {compat_kwargs}")
+            self.model.enable_compatibility_mode(**compat_kwargs)
 
         # Inspect TransformerBridge after instantiation
         inspect_state_dict_or_params(
@@ -578,19 +606,88 @@ if _FTS_AVAILABLE:
     class TransformerBridgeStrategyAdapter(StrategyAdapter):
         """Strategy adapter to support TransformerLens Bridge naming translation.
 
+        Enables fine-tuning schedules to use clean TL-style parameter names (e.g., blocks.9.attn.W_Q)
+        instead of verbose canonical names (e.g., model.blocks.9._original_component.attn.q._original_component.weight).
+
         Handles checkpoint key translation between HF-style and TL-style formats:
         - Checkpoint keys use HF prefixes: model.transformer.h.N, model.transformer.wte, etc.
         - Runtime keys use TL prefixes: model.blocks.N, model.embed, etc.
 
         Uses the TransformerBridge adapter's component_mapping for architecture-agnostic conversion.
+
+        Args:
+            model_view: Optional ModelView instance or class (str/Type) for parameter naming transformation.
+                If None, uses canonical naming (default behavior).
+            model_view_cfg: Optional dict of configuration parameters to pass to ModelView constructor.
+                For example: {'implicit_ln_thaw': False} for TLNamesModelView.
+                Ignored if model_view is already an instance.
+            use_tl_names: Convenience flag. If True, automatically creates TLNamesModelView instance.
+                Cannot be used together with model_view parameter.
         """
 
         # Attach standalone debugging utility as static method
         inspect_state = staticmethod(inspect_state_dict_or_params)
 
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(
+            self,
+            model_view: Union[None, str, Type[ModelView], ModelView] = None,
+            model_view_cfg: Optional[Dict[str, Any]] = None,
+            use_tl_names: bool = False,
+            *args,
+            **kwargs,
+        ) -> None:
             super().__init__(*args, **kwargs)
+
+            # Validate mutually exclusive parameters
+            if model_view is not None and use_tl_names:
+                raise ValueError("Cannot specify both 'model_view' and 'use_tl_names'. Use one or the other.")
+
+            # Store initialization parameters for deferred model_view creation
+            # (model_view needs access to adapter, so we create it in on_before_init_fts)
+            # If nothing specified, we'll use CanonicalModelView (identity transformation)
+            self._model_view_init: Union[None, str, Type[ModelView], ModelView] = model_view
+            self._model_view_cfg: Dict[str, Any] = model_view_cfg or {}
+            self._use_tl_names: bool = use_tl_names
+            self.model_view: Optional[ModelView] = None
+
+            # Always use translation function (even for canonical mode via CanonicalModelView)
             self.exec_ft_phase = partial(StrategyAdapter.base_ft_phase, translation_func=self.logical_param_translation)
+
+        def _ensure_model_view_initialized(self) -> None:
+            """Ensure model_view is initialized before use.
+
+            This is called from methods that may be invoked before on_before_init_fts(), such as gen_ft_schedule() when
+            gen_ft_sched_only=True.
+            """
+            if self.model_view is not None:
+                return  # Already initialized
+
+            # Initialize model_view on demand (or triggered by on_before_init_fts hasn't run yet)
+            if self._use_tl_names:
+                self.model_view = TLNamesModelView(self, **self._model_view_cfg)
+            elif self._model_view_init is not None:
+                if isinstance(self._model_view_init, str):
+                    view_class = _import_class(self._model_view_init)
+                    self.model_view = view_class(self, **self._model_view_cfg)
+                elif isinstance(self._model_view_init, type):
+                    self.model_view = self._model_view_init(self, **self._model_view_cfg)
+                elif isinstance(self._model_view_init, ModelView):
+                    if self._model_view_cfg:
+                        rank_zero_warn(
+                            "model_view_cfg provided but model_view is already an instance. "
+                            "Configuration will be ignored."
+                        )
+                    self.model_view = self._model_view_init
+                else:
+                    raise TypeError(
+                        f"model_view must be None, str, Type[ModelView], or ModelView instance. "
+                        f"Got: {type(self._model_view_init)}"
+                    )
+            else:
+                self.model_view = CanonicalModelView(self, **self._model_view_cfg)
+
+            # Build parameter mapping
+            self.model_view.build_param_mapping()
 
         def on_before_init_fts(self) -> None:
             # we patch our wrapped TransformerBridge module to use the TransformerBridge's state_dict and
@@ -598,11 +695,91 @@ if _FTS_AVAILABLE:
             setattr(self.pl_module, "state_dict", self.pl_module.model.state_dict)
             setattr(self.pl_module, "load_state_dict", self.pl_module.model.load_state_dict)
 
-        def logical_param_translation(self, param_names: List[str]) -> List[str]:
-            return param_names
+            # Ensure model_view is initialized (may already be initialized if gen_ft_sched_only=True)
+            self._ensure_model_view_initialized()
+
+        def on_before_restore_optimizers_and_lrs(self) -> None:
+            """Allow inspection for now.
+
+            May be necessary so we can allow adapter to manage the movement of restored optimizer states to the relevant
+            devices.
+            """
+            checkpoint_connector = self.trainer._checkpoint_connector
+            _ = checkpoint_connector._loaded_checkpoint["optimizer_states"]
 
         def fts_optim_transform(self, orig_pl: List[str], inspect_only: bool = False) -> List[str]:
-            return orig_pl
+            """Transform parameter names to canonical names for optimizer.
+
+            Delegates transformation to the active model view.
+
+            Args:
+                orig_pl: List of parameter names from schedule
+                inspect_only: If True, only validate mapping without transforming
+
+            Returns:
+                List of canonical parameter names for optimizer
+            """
+            return self.model_view.transform_to_canonical(orig_pl, inspect_only=inspect_only)
+
+        def logical_param_translation(self, param_names: List[str]) -> List[str]:
+            """Translate canonical parameter names to model view names.
+
+            Delegates transformation to the active model view.
+
+            Args:
+                param_names: List of canonical parameter names from optimizer
+
+            Returns:
+                List of model view parameter names
+            """
+            return self.model_view.transform_from_canonical(param_names)
+
+        def get_named_params_for_schedule_validation(self) -> Dict[str, torch.Tensor]:
+            """Get named parameters for schedule validation.
+
+            Delegates to the active model view for parameter naming.
+
+            Returns:
+                Dict[str, torch.Tensor]: A dictionary mapping parameter names to parameter tensors.
+            """
+            self._ensure_model_view_initialized()
+            return self.model_view.get_named_params()
+
+        def validate_ft_sched(self) -> Tuple[int, int]:
+            """Validate the fine-tuning schedule.
+
+            Delegates to the active model view's validation method.
+
+            Returns:
+                Tuple[int, int]: A tuple of ints specifying:
+                    1. The depth of the final scheduled phase
+                    2. The maximum epoch watermark explicitly specified in the schedule
+            """
+            self._ensure_model_view_initialized()
+            rank_zero_debug(
+                f"[TransformerBridgeStrategyAdapter.validate_ft_sched] Using {self.model_view.__class__.__name__} "
+                f"for schedule validation (module: {self.pl_module.__class__.__name__})"
+            )
+            # Delegate to model view's validation (which calls base StrategyAdapter implementation)
+            return self.model_view.validate_schedule()
+
+        def gen_ft_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
+            """Generate fine-tuning schedule using active model view naming.
+
+            Delegates to the active model view's generation method.
+
+            Args:
+                dump_loc: Directory to write the generated schedule
+
+            Returns:
+                Path to the generated schedule YAML file
+            """
+            self._ensure_model_view_initialized()
+            rank_zero_debug(
+                f"[TransformerBridgeStrategyAdapter.gen_ft_schedule] Using {self.model_view.__class__.__name__} "
+                f"for schedule generation (module: {self.pl_module.__class__.__name__})"
+            )
+            return self.model_view.gen_schedule(dump_loc)
 
         def lightning_module_state_dict(self) -> dict[str, Any]:
             """Override lightning_module_state_dict to use TransformerBridge state_dict to avoid dup keys."""
@@ -617,5 +794,494 @@ if _FTS_AVAILABLE:
             assert self.pl_module is not None
             self.pl_module.model.load_state_dict(checkpoint["state_dict"], strict=strict)
 
+    class TLNamesModelView(ModelView):
+        """TransformerLens-style parameter naming strategy.
+
+        Provides clean TL-style names (e.g., blocks.9.attn.W_Q) instead of verbose
+        canonical names. Optionally includes implicit LayerNorm thawing since TL
+        nomenclature doesn't include LayerNorm parameters.
+
+        Args:
+            adapter: The strategy adapter instance
+            implicit_ln_thaw: If True (default), automatically thaws LayerNorm parameters
+                when attention or MLP blocks are thawed. If False, LayerNorms are not
+                implicitly thawed and must be explicitly included in schedules if needed.
+
+        Note:
+            Users needing fine-grained LayerNorm control can either use canonical mode
+            or set implicit_ln_thaw=False and explicitly manage LayerNorm parameters.
+        """
+
+        def __init__(self, adapter: "StrategyAdapter", implicit_ln_thaw: bool = True):
+            super().__init__(adapter)
+            self.implicit_ln_thaw = implicit_ln_thaw
+            self._tl_to_canonical_mapping: Optional[Dict[str, List[str]]] = None
+            self._canonical_to_tl_mapping: Optional[Dict[str, str]] = None
+            self._unmapped_canonical_params: Optional[set] = None
+
+        def build_param_mapping(self) -> None:
+            """Build bidirectional parameter name mappings using component structure tracing.
+
+            Creates mappings between TL-style names (e.g., blocks.9.attn.W_Q) and canonical names
+            (e.g., model.blocks.9._original_component.attn.q._original_component.weight).
+
+            Uses tl_named_parameters() as the source of truth for TL naming, then traces
+            back to the underlying component tensors via data_ptr() to find canonical matches.
+            This approach works for any architecture since it introspects the actual bridge
+            component structure rather than relying on hardcoded pattern lists.
+
+            Note on LayerNorm parameters:
+                Canonical LayerNorm parameters (ln_1, ln_2, ln_final) are always present in
+                named_parameters() but are NOT mapped to TL parameters. This is expected:
+                - TransformerLens (if configured to) folds LayerNorm into subsequent layers mathematically
+                - The canonical params remain (weight=1, bias=0 when folded) but have no TL equivalent
+                - These canonical LayerNorm params appear in `unmapped_canonical` and can be
+                  handled specially during schedule validation
+            """
+            rank_zero_info("Building TL-style to canonical parameter name mapping...")
+
+            bridge = self.pl_module.model
+
+            # Get TL-style parameter names (source of truth for TL naming)
+            tl_params = dict(bridge.tl_named_parameters())
+
+            # Get canonical parameters
+            canonical_params = dict(self.pl_module.named_parameters())
+
+            # Build index of canonical params by data_ptr for efficient lookup
+            canonical_by_ptr: Dict[int, List[str]] = {}
+            for name, tensor in canonical_params.items():
+                ptr = tensor.data_ptr()
+                if ptr not in canonical_by_ptr:
+                    canonical_by_ptr[ptr] = []
+                canonical_by_ptr[ptr].append(name)
+
+            # Build mappings using component structure tracing
+            self._tl_to_canonical_mapping = {}
+            self._canonical_to_tl_mapping = {}
+
+            for tl_name in tl_params.keys():
+                # Get the underlying component tensor (not the TL view)
+                underlying_tensor = self._get_underlying_component_tensor(tl_name, bridge)
+
+                if underlying_tensor is not None:
+                    ptr = underlying_tensor.data_ptr()
+                    if ptr in canonical_by_ptr:
+                        canonical_names = canonical_by_ptr[ptr]
+                        self._tl_to_canonical_mapping[tl_name] = canonical_names
+                        for canonical_name in canonical_names:
+                            self._canonical_to_tl_mapping[canonical_name] = tl_name
+                    else:
+                        # Underlying tensor exists but no canonical match - unexpected
+                        rank_zero_debug(f"TL param '{tl_name}' has underlying tensor but no canonical match")
+                        self._tl_to_canonical_mapping[tl_name] = []
+                else:
+                    # No underlying tensor found - might be a virtual param
+                    self._tl_to_canonical_mapping[tl_name] = []
+
+            # Validate mapping completeness
+            unmapped_tl = [name for name, mapping in self._tl_to_canonical_mapping.items() if not mapping]
+            unmapped_canonical = set(canonical_params.keys()) - set(self._canonical_to_tl_mapping.keys())
+
+            if unmapped_tl:
+                # Report any unmapped TL params - this is unexpected since we trace through components
+                rank_zero_warn(
+                    f"Warning: {len(unmapped_tl)} TL-style parameters could not be mapped to canonical params. "
+                    f"First few: {unmapped_tl[:5]}"
+                )
+
+            # Store unmapped canonical params for later use in validation
+            # Expected unmapped canonical params vary by architecture, e.g.:
+            # - LayerNorm params (ln_1, ln_2, ln_final) - TL often folds these into subsequent layers, irrespective of
+            #   folding though, does not expose them when following the TL naming convention
+            # - Combined QKV params - TL exposes separate W_Q, W_K, W_V instead of joint e.g. c_attn
+            self._unmapped_canonical_params = unmapped_canonical
+
+            if unmapped_canonical:
+                rank_zero_debug(
+                    f"{len(unmapped_canonical)} canonical parameters have no TL-style equivalent. "
+                    f"First few: {list(unmapped_canonical)[:5]}"
+                )
+
+            rank_zero_info(
+                f"Mapping complete: {len(self._tl_to_canonical_mapping)} TL-style → "
+                f"{sum(len(v) for v in self._tl_to_canonical_mapping.values())} canonical parameters"
+            )
+
+        def transform_to_canonical(self, param_names: List[str], inspect_only: bool = False) -> List[str]:
+            """Transform TL-style parameter names to canonical names for optimizer.
+
+            If implicit_ln_thaw=True, this method also appends LayerNorm parameters
+            for the layers being thawed (since TL nomenclature doesn't include LayerNorm).
+            If implicit_ln_thaw=False, only the explicitly specified TL params are transformed.
+
+            Args:
+                param_names: List of parameter names from schedule (TL-style)
+                inspect_only: If True, only validate mapping without transforming
+
+            Returns:
+                List of canonical parameter names for optimizer
+            """
+            assert self._tl_to_canonical_mapping is not None, (
+                "Parameter mapping not initialized. Call build_param_mapping() first."
+            )
+
+            canonical_params = []
+            for tl_name in param_names:
+                if tl_name not in self._tl_to_canonical_mapping:
+                    raise ValueError(
+                        f"TL-style parameter '{tl_name}' not found in mapping. "
+                        f"Available TL names: {list(self._tl_to_canonical_mapping.keys())[:10]}..."
+                    )
+
+                # A TL parameter may map to multiple canonical parameters (views)
+                canonical_names = self._tl_to_canonical_mapping[tl_name]
+                if not canonical_names:
+                    raise ValueError(f"TL-style parameter '{tl_name}' has no canonical mapping")
+
+                canonical_params.extend(canonical_names)
+
+            # Append implicit LayerNorm params if enabled
+            # TL nomenclature doesn't include LayerNorm, but canonical params need them for training
+            implicit_ln_params = []
+            if self.implicit_ln_thaw:
+                implicit_ln_params = self._get_implicit_layernorm_params(param_names)
+                canonical_params.extend(implicit_ln_params)
+
+            if not inspect_only:
+                if self.implicit_ln_thaw:
+                    rank_zero_debug(
+                        f"Transformed {len(param_names)} TL-style params → {len(canonical_params)} canonical params "
+                        f"(including {len(implicit_ln_params)} implicit LayerNorm params)"
+                    )
+                else:
+                    rank_zero_debug(
+                        f"Transformed {len(param_names)} TL-style params → {len(canonical_params)} canonical params "
+                        f"(implicit_ln_thaw=False, no LayerNorm params added)"
+                    )
+
+            return canonical_params
+
+        def transform_from_canonical(self, param_names: List[str]) -> List[str]:
+            """Translate canonical parameter names to TL-style names.
+
+            Args:
+                param_names: List of canonical parameter names from optimizer
+
+            Returns:
+                List of TL-style parameter names (or canonical if no mapping exists)
+            """
+            assert self._canonical_to_tl_mapping is not None, (
+                "Parameter mapping not initialized. Call build_param_mapping() first."
+            )
+
+            tl_params = []
+            for canonical_name in param_names:
+                if canonical_name not in self._canonical_to_tl_mapping:
+                    # Some canonical parameters might not have TL equivalents (e.g., LayerNorm)
+                    rank_zero_debug(
+                        f"Canonical parameter '{canonical_name}' not found in reverse mapping, keeping as-is"
+                    )
+                    tl_params.append(canonical_name)
+                else:
+                    tl_params.append(self._canonical_to_tl_mapping[canonical_name])
+
+            # Remove duplicates while preserving order
+            seen = set()
+            unique_tl_params = []
+            for name in tl_params:
+                if name not in seen:
+                    seen.add(name)
+                    unique_tl_params.append(name)
+
+            return unique_tl_params
+
+        def get_named_params(self) -> Dict[str, torch.Tensor]:
+            """Get named parameters for schedule validation.
+
+            Returns TL-style parameter names from the TransformerBridge.
+
+            Returns:
+                Dict[str, torch.Tensor]: A dictionary mapping TL-style names to parameter tensors.
+            """
+            return dict(self.pl_module.model.tl_named_parameters())
+
+        def gen_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
+            """Generate fine-tuning schedule using TL-style parameter names.
+
+            Generates schedule with clean TL-style names (e.g., blocks.9.attn.W_Q).
+
+            Args:
+                dump_loc: Directory to write the generated schedule
+
+            Returns:
+                Path to the generated schedule YAML file
+            """
+            from finetuning_scheduler.fts_supporters import ScheduleImplMixin
+
+            # Generate schedule with TL-style names
+            rank_zero_debug("TLNamesModelView.gen_schedule() called")
+            rank_zero_info(f"Generating TL-style fine-tuning schedule for {self.pl_module.__class__.__name__}")
+
+            param_lists: List = []
+            cur_group: List = []
+
+            # Use TL-style parameter names
+            model_params = list(self.pl_module.model.tl_named_parameters())[::-1]
+
+            # Apply 2-parameters per-level heuristic
+            for i, (n, _) in enumerate(model_params):
+                if i % 2 == 0:
+                    cur_group = []
+                    cur_group.append(n)
+                else:
+                    cur_group.append(n)
+                    param_lists.append(cur_group)
+
+            if len(model_params) % 2 == 1:
+                param_lists.append([model_params[-1][0]])
+
+            # Build schedule config
+            layer_config = {}
+            for i, param_l in enumerate(param_lists):
+                layer_config[i] = {"params": param_l}
+
+            schedule_name = f"{self.pl_module.__class__.__name__}_ft_schedule.yaml"
+            assert dump_loc is not None
+            return ScheduleImplMixin.save_schedule(schedule_name, layer_config, dump_loc)
+
+        def validate_schedule(self) -> Tuple[int, int]:
+            """Validate the fine-tuning schedule with TL-style parameter mapping diagnostics.
+
+            Logs diagnostic information about the parameter mappings before delegating
+            to the standard validation. This helps debug schedule issues and understand
+            which canonical LayerNorm params are unmapped.
+
+            Returns:
+                Tuple[int, int]: A tuple of ints specifying:
+                    1. The depth of the final scheduled phase
+                    2. The maximum epoch watermark explicitly specified in the schedule
+            """
+            rank_zero_debug("TLNamesModelView.validate_schedule() called")
+            if self._tl_to_canonical_mapping is not None:
+                # Log mapping diagnostics for debugging
+                rank_zero_debug(
+                    f"TL-style schedule validation - TL→Canonical mapping summary:\n"
+                    f"  Total TL params: {len(self._tl_to_canonical_mapping)}\n"
+                    f"  Total mapped canonical params: {len(self._canonical_to_tl_mapping)}"
+                )
+
+                # Log unmapped canonical params (expected to include LayerNorms)
+                if self._unmapped_canonical_params:
+                    # Categorize unmapped canonical params
+                    ln_params = [p for p in self._unmapped_canonical_params if "ln_" in p or "ln_final" in p]
+                    other_params = [p for p in self._unmapped_canonical_params if p not in ln_params]
+
+                    rank_zero_debug(
+                        f"Unmapped canonical parameters ({len(self._unmapped_canonical_params)} total):\n"
+                        f"  LayerNorm params: {len(ln_params)} (expected - TL nomenclature does not include these)\n"
+                        f"  Other params: {len(other_params)} (e.g., combined QKV)"
+                    )
+
+                    if ln_params:
+                        rank_zero_debug(f"  LayerNorm sample: {ln_params[:3]}")
+                    if other_params:
+                        rank_zero_debug(f"  Other sample: {other_params[:3]}")
+
+            # Delegate to base StrategyAdapter validation
+            from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+
+            return StrategyAdapter.validate_ft_sched(self.adapter)
+
+        # Private helper methods for component structure tracing
+
+        def _get_underlying_component_tensor(self, tl_name: str, bridge: Any) -> Optional[torch.Tensor]:
+            """Get the underlying component tensor for a TL-style parameter name.
+
+            Maps TL names like 'blocks.0.attn.W_Q' to the actual component tensor
+            (bridge.blocks[0].attn.q.weight), which shares data_ptr with canonical params.
+
+            The TL tensors from tl_named_parameters() may be views/reshapes (via einops),
+            but the underlying component tensors are the actual nn.Parameter objects.
+
+            Args:
+                tl_name: TL-style parameter name from tl_named_parameters()
+                bridge: TransformerBridge instance
+
+            Returns:
+                The underlying component tensor if found, None otherwise.
+            """
+            parts = tl_name.split(".")
+
+            try:
+                if parts[0] == "blocks":
+                    layer_idx = int(parts[1])
+                    block = bridge.blocks[layer_idx]
+                    component_type = parts[2]  # attn, mlp, ln1, ln2
+                    param_name = parts[3]  # W_Q, b_Q, W_in, w, etc.
+
+                    if component_type == "attn":
+                        return self._get_attn_component_tensor(block.attn, param_name)
+                    elif component_type == "mlp":
+                        return self._get_mlp_component_tensor(block.mlp, param_name)
+                    elif component_type in ("ln1", "ln2"):
+                        ln = block.ln_1 if component_type == "ln1" else getattr(block, "ln_2", None)
+                        if ln is not None:
+                            return self._get_ln_component_tensor(ln, param_name)
+
+                elif parts[0] == "embed":
+                    return getattr(bridge.embed, "weight", None)
+
+                elif parts[0] == "pos_embed":
+                    pos_embed = getattr(bridge, "pos_embed", None)
+                    if pos_embed is not None:
+                        return getattr(pos_embed, "weight", None)
+
+                elif parts[0] == "unembed":
+                    if parts[1] == "W_U":
+                        return getattr(bridge.unembed, "weight", None)
+                    elif parts[1] == "b_U":
+                        return getattr(bridge.unembed, "bias", None)
+
+                elif parts[0] == "ln_final":
+                    ln_final = getattr(bridge, "ln_final", None)
+                    if ln_final is not None:
+                        return self._get_ln_component_tensor(ln_final, parts[1])
+
+            except (AttributeError, IndexError, KeyError, ValueError) as e:
+                rank_zero_debug(f"Failed to trace TL name '{tl_name}': {e}")
+
+            return None
+
+        def _get_attn_component_tensor(self, attn: Any, param_name: str) -> Optional[torch.Tensor]:
+            """Get attention component tensor.
+
+            Maps TL attention param names to underlying component tensors:
+            - W_Q -> attn.q.weight
+            - W_K -> attn.k.weight
+            - W_V -> attn.v.weight
+            - W_O -> attn.o.weight
+            - b_Q -> attn.q.bias
+            - etc.
+            """
+            # Map param suffix to (component_attr, tensor_attr)
+            mapping = {
+                "W_Q": ("q", "weight"),
+                "W_K": ("k", "weight"),
+                "W_V": ("v", "weight"),
+                "W_O": ("o", "weight"),
+                "b_Q": ("q", "bias"),
+                "b_K": ("k", "bias"),
+                "b_V": ("v", "bias"),
+                "b_O": ("o", "bias"),
+            }
+
+            if param_name in mapping:
+                comp_name, attr_name = mapping[param_name]
+                comp = getattr(attn, comp_name, None)
+                if comp is not None:
+                    return getattr(comp, attr_name, None)
+
+            return None
+
+        def _get_mlp_component_tensor(self, mlp: Any, param_name: str) -> Optional[torch.Tensor]:
+            """Get MLP component tensor.
+
+            Maps TL MLP param names to underlying component tensors:
+            - W_in -> mlp.in.weight (or mlp.input.weight)
+            - W_out -> mlp.out.weight
+            - W_gate -> mlp.gate.weight
+            - b_in -> mlp.in.bias
+            - etc.
+            """
+            if param_name == "W_in":
+                comp = getattr(mlp, "in", None) or getattr(mlp, "input", None)
+                return getattr(comp, "weight", None) if comp else None
+            elif param_name == "b_in":
+                comp = getattr(mlp, "in", None) or getattr(mlp, "input", None)
+                return getattr(comp, "bias", None) if comp else None
+            elif param_name == "W_out":
+                comp = getattr(mlp, "out", None)
+                return getattr(comp, "weight", None) if comp else None
+            elif param_name == "b_out":
+                comp = getattr(mlp, "out", None)
+                return getattr(comp, "bias", None) if comp else None
+            elif param_name == "W_gate":
+                comp = getattr(mlp, "gate", None)
+                return getattr(comp, "weight", None) if comp else None
+            elif param_name == "b_gate":
+                comp = getattr(mlp, "gate", None)
+                return getattr(comp, "bias", None) if comp else None
+
+            return None
+
+        def _get_ln_component_tensor(self, ln: Any, param_name: str) -> Optional[torch.Tensor]:
+            """Get LayerNorm/RMSNorm component tensor.
+
+            Maps TL LayerNorm param names to underlying component tensors:
+            - w -> ln.weight
+            - b -> ln.bias
+            """
+            if param_name in ("w", "weight"):
+                return getattr(ln, "weight", None)
+            elif param_name in ("b", "bias"):
+                return getattr(ln, "bias", None)
+
+            return None
+
+        def _get_implicit_layernorm_params(self, tl_param_names: List[str]) -> List[str]:
+            """Get implicit LayerNorm canonical params for the layers referenced by TL params.
+
+            TL-style nomenclature doesn't include LayerNorm parameters, but canonical training
+            needs them. This method extracts the layer indices from TL param names and returns
+            the corresponding canonical LayerNorm params.
+
+            For each layer index found in tl_param_names:
+            - Adds ln_1 params (weight/bias) for that block
+            - Adds ln_2 params (weight/bias) for that block
+
+            Also handles embeddings:
+            - If any embed/unembed params are present, includes ln_final
+
+            Args:
+                tl_param_names: List of TL-style parameter names being thawed
+
+            Returns:
+                List of canonical LayerNorm parameter names to implicitly thaw
+            """
+            if not self._unmapped_canonical_params:
+                return []
+
+            implicit_ln_params: List[str] = []
+            layer_indices_seen: set = set()
+            has_embed_params = False
+
+            # Extract layer indices from TL param names
+            block_pattern = re.compile(r"^blocks\.(\d+)\.")
+
+            for tl_name in tl_param_names:
+                match = block_pattern.match(tl_name)
+                if match:
+                    layer_indices_seen.add(int(match.group(1)))
+                elif tl_name.startswith(("embed.", "pos_embed.", "unembed.")):
+                    has_embed_params = True
+
+            # Find matching LayerNorm params from unmapped canonical params
+            for canonical_name in sorted(self._unmapped_canonical_params):
+                # Check for block LayerNorm params (ln_1, ln_2)
+                block_ln_match = re.search(r"blocks\.(\d+)\..*?(ln_1|ln_2)", canonical_name)
+                if block_ln_match:
+                    layer_idx = int(block_ln_match.group(1))
+                    if layer_idx in layer_indices_seen:
+                        implicit_ln_params.append(canonical_name)
+                        continue
+
+                # Check for ln_final (associated with embeddings/unembed)
+                if has_embed_params and "ln_final" in canonical_name:
+                    implicit_ln_params.append(canonical_name)
+
+            return implicit_ln_params
+
 else:
     TransformerBridgeStrategyAdapter = object
+    TLNamesModelView = object

--- a/src/interpretune/adapters/transformer_lens.py
+++ b/src/interpretune/adapters/transformer_lens.py
@@ -19,7 +19,7 @@ from transformers.tokenization_utils_base import BatchEncoding
 
 from interpretune.adapters import CompositionRegistry, LightningDataModule, LightningModule, LightningAdapter
 from interpretune.base import CoreHelperAttributes, ITDataModule, BaseITModule
-from interpretune.utils import move_data_to_device, rank_zero_warn, rank_zero_info, _FTS_AVAILABLE
+from interpretune.utils import move_data_to_device, rank_zero_warn, rank_zero_info, rank_zero_debug, _FTS_AVAILABLE
 from interpretune.protocol import Adapter
 
 
@@ -236,49 +236,40 @@ class BaseITLensModule(BaseITModule):
 
         # Create adapter and bridge
         adapter = ArchitectureAdapterFactory.select_architecture_adapter(bridge_config)
-        ### TMP DEBUG SHIM START - Checkpoint Format Investigation ###
-        rank_zero_info("=== BRIDGE CONVERSION DEBUG ===")
+        ### TMP DEBUG SHIM START ###
+        rank_zero_debug("=== BRIDGE CONVERSION DEBUG ===")
 
         # 1. Capture HF model state dict
         hf_state_dict = hf_model.state_dict()
         hf_keys_sample = list(hf_state_dict.keys())[:10]
-        rank_zero_info(f"HF model state_dict keys (sample): {hf_keys_sample}")
+        rank_zero_debug(f"HF model state_dict keys (sample): {hf_keys_sample}")
 
         # 2. Create Bridge
+        ### TMP DEBUG SHIM END ###
         self.model = TransformerBridge(model=hf_model, adapter=adapter, tokenizer=tokenizer_handle)
 
+        # Debug shim: log component mapping for troubleshooting checkpoint restoration
+        if hasattr(adapter, "component_mapping"):
+            component_mapping = adapter.component_mapping
+            hf_prefixes = {getattr(c, "name", "?").split(".")[0] for c in component_mapping.values()}
+            rank_zero_debug(f"TransformerBridge component_mapping keys: {list(component_mapping.keys())}")
+            rank_zero_debug(f"TransformerBridge HF top-level prefixes: {hf_prefixes}")
+
+        ### TMP DEBUG SHIM START ###
         # 3. Capture Bridge model state dict (default - should return TL style keys)
         bridge_state_dict = self.model.state_dict()
         bridge_keys_sample = list(bridge_state_dict.keys())[:10]
-        rank_zero_info(f"Bridge model.state_dict() keys (sample): {bridge_keys_sample}")
+        rank_zero_debug(f"Bridge model.state_dict() keys (sample): {bridge_keys_sample}")
 
         # 4. Capture Bridge TL-style state dict (if different)
         tl_params = {n: p.shape for n, p in self.model.tl_named_parameters()}
         tl_keys_sample = list(tl_params.keys())[:10]
-        rank_zero_info(f"Bridge tl_named_parameters() keys (sample): {tl_keys_sample}")
+        rank_zero_debug(f"Bridge tl_named_parameters() keys (sample): {tl_keys_sample}")
 
         # 5. Capture Bridge runtime parameters (named_parameters - what optimizer sees)
         runtime_params = {n: p.shape for n, p in self.model.named_parameters()}
         runtime_keys_sample = list(runtime_params.keys())[:10]
-        rank_zero_info(f"Bridge named_parameters() keys (sample): {runtime_keys_sample}")
-
-        # 6. Test specific parameter for detailed investigation
-        test_param_hf = "transformer.h.9.mlp.c_proj.weight"
-        test_param_tl = "blocks.9.mlp.W_out"
-        test_param_runtime = "blocks.9._original_component.mlp._original_component.c_proj._original_component.weight"
-
-        if test_param_hf in hf_state_dict:
-            rank_zero_info(f"Found in HF: {test_param_hf}, shape: {hf_state_dict[test_param_hf].shape}")
-        if test_param_tl in bridge_state_dict:
-            rank_zero_info(
-                f"Found in Bridge state_dict: {test_param_tl}, shape: {bridge_state_dict[test_param_tl].shape}"
-            )
-        if test_param_runtime in runtime_params:
-            rank_zero_info(
-                f"Found in runtime params: {test_param_runtime}, shape: {runtime_params[test_param_runtime]}"
-            )
-
-        rank_zero_info("=== END BRIDGE CONVERSION DEBUG ===")
+        rank_zero_debug(f"Bridge named_parameters() keys (sample): {runtime_keys_sample}")
         ### TMP DEBUG SHIM END ###
         # Move model to device if move_to_device is enabled (default True)
         if pruned_cfg.get("move_to_device", True) and "device" in pruned_cfg:
@@ -384,13 +375,18 @@ if _FTS_AVAILABLE:
     class TransformerBridgeStrategyAdapter(StrategyAdapter):
         """Strategy adapter to support TransformerLens Bridge naming translation.
 
-        NOTE: This is a minimal implementation that keeps identity mapping for Phase 0.
-        Future work will implement canonical HF name mapping and save/restore mapping.
+        Handles checkpoint key translation between HF-style and TL-style formats:
+        - Checkpoint keys use HF prefixes: model.transformer.h.N, model.transformer.wte, etc.
+        - Runtime keys use TL prefixes: model.blocks.N, model.embed, etc.
+
+        Uses the TransformerBridge adapter's component_mapping for architecture-agnostic conversion.
         """
 
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
             self.exec_ft_phase = partial(StrategyAdapter.base_ft_phase, translation_func=self.logical_param_translation)
+            self._component_mapping_cache: Optional[Dict[str, str]] = None
+            self._hf_top_level_prefixes_cache: Optional[set] = None
 
         def logical_param_translation(self, param_names: List[str]) -> List[str]:
             return param_names
@@ -398,66 +394,183 @@ if _FTS_AVAILABLE:
         def fts_optim_transform(self, orig_pl: List[str], inspect_only: bool = False) -> List[str]:
             return orig_pl
 
+        def _get_bridge_adapter(self) -> Optional[Any]:
+            """Get the TransformerBridge adapter from the pl_module if available."""
+            try:
+                model = getattr(self.pl_module, "model", None)
+                if model is not None and hasattr(model, "adapter"):
+                    return model.adapter
+            except Exception:
+                pass
+            return None
+
+        def _build_prefix_mapping(self, adapter: Any) -> Dict[str, str]:
+            """Build HF->TL prefix mapping from the adapter's component_mapping.
+
+            Returns a dict mapping HF prefixes to TL prefixes, e.g.: {     'transformer.wte': 'embed',
+            'transformer.wpe': 'pos_embed',     'transformer.h': 'blocks',     'transformer.ln_f': 'ln_final',
+            'lm_head': 'unembed', }
+
+            Also populates self._hf_top_level_prefixes_cache with unique top-level HF prefixes (e.g., {'transformer',
+            'lm_head'} for GPT-2, {'model', 'lm_head'} for Llama).
+            """
+            if self._component_mapping_cache is not None:
+                return self._component_mapping_cache
+
+            mapping: Dict[str, str] = {}
+            hf_top_level_prefixes: set = set()
+            component_mapping = getattr(adapter, "component_mapping", None)
+            if component_mapping is None:
+                self._hf_top_level_prefixes_cache = hf_top_level_prefixes
+                return mapping
+
+            for tl_name, component in component_mapping.items():
+                hf_path = getattr(component, "name", None)
+                if hf_path is not None:
+                    mapping[hf_path] = tl_name
+                    # Extract top-level prefix (first component of the path)
+                    top_level = hf_path.split(".")[0]
+                    hf_top_level_prefixes.add(top_level)
+
+            self._component_mapping_cache = mapping
+            self._hf_top_level_prefixes_cache = hf_top_level_prefixes
+            return mapping
+
+        def _convert_checkpoint_key_to_runtime(self, ckpt_key: str, prefix_mapping: Dict[str, str]) -> str:
+            """Convert a checkpoint key (HF-style prefix) to runtime key (TL-style prefix).
+
+            Checkpoint: model.transformer.h.0._original_component.attn.q._original_component.weight
+            Runtime:    model.blocks.0._original_component.attn.q._original_component.weight
+
+            Only converts the top-level prefix path. Everything after the first _original_component
+            stays the same since those use TL-style submodule names already.
+            """
+            if not ckpt_key.startswith("model."):
+                return ckpt_key
+
+            key = ckpt_key[6:]  # Remove 'model.' prefix
+            oc_marker = "._original_component"
+
+            # Find the first _original_component - everything before it is the HF prefix to convert
+            first_oc_idx = key.find(oc_marker)
+            if first_oc_idx == -1:
+                # No _original_component - shouldn't happen for bridge keys, return as-is
+                return ckpt_key
+
+            hf_prefix = key[:first_oc_idx]
+            rest = key[first_oc_idx:]  # includes the _original_component
+
+            # Convert HF prefix to TL prefix using mapping
+            tl_prefix = hf_prefix  # default: keep as-is
+
+            # Check for blocks pattern: e.g. transformer.h.N -> blocks.N
+            blocks_hf_prefix = None
+            for hf_path, tl_name in prefix_mapping.items():
+                if tl_name == "blocks":
+                    blocks_hf_prefix = hf_path
+                    break
+
+            if blocks_hf_prefix and hf_prefix.startswith(blocks_hf_prefix + "."):
+                layer_part = hf_prefix[len(blocks_hf_prefix) + 1 :]
+                tl_prefix = f"blocks.{layer_part}"
+            else:
+                # Check other top-level components (exact match)
+                for hf_path, tl_name in prefix_mapping.items():
+                    if hf_prefix == hf_path:
+                        tl_prefix = tl_name
+                        break
+
+            return "model." + tl_prefix + rest
+
         def before_restore_model(self, checkpoint: Dict[str, Any]) -> Dict[str, Any]:
             """Prepare checkpoint for TransformerBridge restoration.
 
             TransformerBridge creates multiple parameter aliases:
-            1. Original HF keys: model.transformer.*
-            2. TL-style aliases: model.blocks.*, model.embed, etc.
-            3. Prefixed HF keys: model.original_model.transformer.*
+            1. Original HF keys in checkpoint: model.transformer.*
+            2. TL-style aliases at runtime: model.embed.*, model.blocks.*, etc.
+            3. Prefixed HF keys at runtime: model.original_model.transformer.*
 
-            Checkpoints only contain the original HF keys. We need to duplicate them with the
-            additional naming patterns so all named_parameters can find their values.
+            Checkpoints contain HF-style keys. We need to transform them to match
+            the runtime module structure:
+            - Add model.original_model.* prefix for HF keys
+            - Add TL-style aliases using adapter component mapping
+
+            Uses the bridge adapter's component_mapping for architecture-agnostic conversion.
             """
             state_dict = checkpoint.get("state_dict", {})
             if not state_dict:
                 return checkpoint
 
+            # Get the bridge adapter for component mapping
+            adapter = self._get_bridge_adapter()
+            if adapter is None:
+                rank_zero_warn(
+                    "TransformerBridgeStrategyAdapter: Could not access bridge adapter. "
+                    "Skipping checkpoint key conversion."
+                )
+                return checkpoint
+
+            prefix_mapping = self._build_prefix_mapping(adapter)
+            if not prefix_mapping:
+                rank_zero_warn(
+                    "TransformerBridgeStrategyAdapter: No component mapping found. Skipping checkpoint key conversion."
+                )
+                return checkpoint
+
             rank_zero_info(
                 "TransformerBridgeStrategyAdapter: Expanding checkpoint keys for TransformerBridge aliases..."
             )
+            rank_zero_debug(f"TransformerBridgeStrategyAdapter: Prefix mapping: {prefix_mapping}")
+
+            # Get HF top-level prefixes for architecture-agnostic original_model prefixing
+            hf_top_level_prefixes = self._hf_top_level_prefixes_cache or set()
+            rank_zero_debug(f"TransformerBridgeStrategyAdapter: HF top-level prefixes: {hf_top_level_prefixes}")
 
             expanded_state_dict = {}
+            sample_conversions = []
+            sample_original_model_keys = []
 
             for key, value in state_dict.items():
-                # Skip direct HF keys - we only want the aliased versions
-                # (The original model.transformer.* and model.lm_head.* keys should not be in expanded dict)
+                if not key.startswith("model."):
+                    # Non-model keys (optimizer states, etc.) pass through unchanged
+                    expanded_state_dict[key] = value
+                    continue
 
-                # Add original_model prefix for HF keys
-                if key.startswith("model.transformer."):
-                    original_model_key = key.replace("model.transformer.", "model.original_model.transformer.", 1)
+                # Extract the component after "model." prefix to check against HF prefixes
+                key_after_model = key[6:]  # Remove "model." prefix
+                matched_hf_prefix = None
+                for hf_prefix in hf_top_level_prefixes:
+                    if key_after_model.startswith(hf_prefix + ".") or key_after_model == hf_prefix:
+                        matched_hf_prefix = hf_prefix
+                        break
+
+                if matched_hf_prefix:
+                    # Add original_model prefix for HF keys (required by runtime module structure)
+                    original_model_key = f"model.original_model.{key_after_model}"
                     expanded_state_dict[original_model_key] = value
-                elif key.startswith("model.lm_head."):
-                    original_model_key = key.replace("model.lm_head.", "model.original_model.lm_head.", 1)
-                    expanded_state_dict[original_model_key] = value
+                    if len(sample_original_model_keys) < 3:
+                        sample_original_model_keys.append(f"{key} -> {original_model_key}")
                 else:
-                    # Keep non-model keys as-is (like optimizer states, etc.)
+                    # Non-HF model keys - keep as-is
                     expanded_state_dict[key] = value
 
-                # Add TL-style alias keys
-                # model.transformer.wte -> model.embed
-                if ".transformer.wte." in key:
-                    tl_key = key.replace(".transformer.wte.", ".embed.")
+                # Add TL-style alias key using component mapping
+                tl_key = self._convert_checkpoint_key_to_runtime(key, prefix_mapping)
+                if tl_key != key:
                     expanded_state_dict[tl_key] = value
-                # model.transformer.wpe -> model.pos_embed
-                elif ".transformer.wpe." in key:
-                    tl_key = key.replace(".transformer.wpe.", ".pos_embed.")
-                    expanded_state_dict[tl_key] = value
-                # model.transformer.h.N -> model.blocks.N
-                elif ".transformer.h." in key:
-                    tl_key = key.replace(".transformer.h.", ".blocks.")
-                    expanded_state_dict[tl_key] = value
-                # model.transformer.ln_f -> model.ln_final
-                elif ".transformer.ln_f." in key:
-                    tl_key = key.replace(".transformer.ln_f.", ".ln_final.")
-                    expanded_state_dict[tl_key] = value
-                # model.lm_head -> model.unembed
-                elif ".lm_head." in key:
-                    tl_key = key.replace(".lm_head.", ".unembed.")
-                    expanded_state_dict[tl_key] = value
+                    if len(sample_conversions) < 5:
+                        sample_conversions.append(f"{key} -> {tl_key}")
 
             checkpoint["state_dict"] = expanded_state_dict
-            rank_zero_info(f"Expanded {len(state_dict)} keys to {len(expanded_state_dict)} keys with aliases")
+            rank_zero_info(
+                f"TransformerBridgeStrategyAdapter: Expanded {len(state_dict)} keys to {len(expanded_state_dict)} keys"
+            )
+            if sample_original_model_keys:
+                rank_zero_debug(
+                    f"TransformerBridgeStrategyAdapter: Sample original_model prefixing: {sample_original_model_keys}"
+                )
+            if sample_conversions:
+                rank_zero_debug(f"TransformerBridgeStrategyAdapter: Sample TL conversions: {sample_conversions}")
 
             return checkpoint
 

--- a/src/interpretune/adapters/transformer_lens.py
+++ b/src/interpretune/adapters/transformer_lens.py
@@ -1,7 +1,7 @@
 import os
-from typing import Optional, Type, cast, Union
+from typing import Optional, Type, cast, Union, Dict, Any, List
 import inspect
-from functools import reduce
+from functools import reduce, partial
 from copy import deepcopy
 
 import torch
@@ -19,7 +19,7 @@ from transformers.tokenization_utils_base import BatchEncoding
 
 from interpretune.adapters import CompositionRegistry, LightningDataModule, LightningModule, LightningAdapter
 from interpretune.base import CoreHelperAttributes, ITDataModule, BaseITModule
-from interpretune.utils import move_data_to_device, rank_zero_warn, rank_zero_info
+from interpretune.utils import move_data_to_device, rank_zero_warn, rank_zero_info, _FTS_AVAILABLE
 from interpretune.protocol import Adapter
 
 
@@ -236,8 +236,50 @@ class BaseITLensModule(BaseITModule):
 
         # Create adapter and bridge
         adapter = ArchitectureAdapterFactory.select_architecture_adapter(bridge_config)
+        ### TMP DEBUG SHIM START - Checkpoint Format Investigation ###
+        rank_zero_info("=== BRIDGE CONVERSION DEBUG ===")
+
+        # 1. Capture HF model state dict
+        hf_state_dict = hf_model.state_dict()
+        hf_keys_sample = list(hf_state_dict.keys())[:10]
+        rank_zero_info(f"HF model state_dict keys (sample): {hf_keys_sample}")
+
+        # 2. Create Bridge
         self.model = TransformerBridge(model=hf_model, adapter=adapter, tokenizer=tokenizer_handle)
 
+        # 3. Capture Bridge model state dict (default - should return TL style keys)
+        bridge_state_dict = self.model.state_dict()
+        bridge_keys_sample = list(bridge_state_dict.keys())[:10]
+        rank_zero_info(f"Bridge model.state_dict() keys (sample): {bridge_keys_sample}")
+
+        # 4. Capture Bridge TL-style state dict (if different)
+        tl_params = {n: p.shape for n, p in self.model.tl_named_parameters()}
+        tl_keys_sample = list(tl_params.keys())[:10]
+        rank_zero_info(f"Bridge tl_named_parameters() keys (sample): {tl_keys_sample}")
+
+        # 5. Capture Bridge runtime parameters (named_parameters - what optimizer sees)
+        runtime_params = {n: p.shape for n, p in self.model.named_parameters()}
+        runtime_keys_sample = list(runtime_params.keys())[:10]
+        rank_zero_info(f"Bridge named_parameters() keys (sample): {runtime_keys_sample}")
+
+        # 6. Test specific parameter for detailed investigation
+        test_param_hf = "transformer.h.9.mlp.c_proj.weight"
+        test_param_tl = "blocks.9.mlp.W_out"
+        test_param_runtime = "blocks.9._original_component.mlp._original_component.c_proj._original_component.weight"
+
+        if test_param_hf in hf_state_dict:
+            rank_zero_info(f"Found in HF: {test_param_hf}, shape: {hf_state_dict[test_param_hf].shape}")
+        if test_param_tl in bridge_state_dict:
+            rank_zero_info(
+                f"Found in Bridge state_dict: {test_param_tl}, shape: {bridge_state_dict[test_param_tl].shape}"
+            )
+        if test_param_runtime in runtime_params:
+            rank_zero_info(
+                f"Found in runtime params: {test_param_runtime}, shape: {runtime_params[test_param_runtime]}"
+            )
+
+        rank_zero_info("=== END BRIDGE CONVERSION DEBUG ===")
+        ### TMP DEBUG SHIM END ###
         # Move model to device if move_to_device is enabled (default True)
         if pruned_cfg.get("move_to_device", True) and "device" in pruned_cfg:
             device = pruned_cfg["device"]
@@ -333,3 +375,91 @@ class TransformerLensAdapter(TLensAttributeMixin):
 
 
 class ITLensModule(TransformerLensAdapter, CoreHelperAttributes, BaseITLensModule): ...
+
+
+if _FTS_AVAILABLE:
+    from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
+
+    # Strategy adapter for TransformerLens Bridge integration
+    class TransformerBridgeStrategyAdapter(StrategyAdapter):
+        """Strategy adapter to support TransformerLens Bridge naming translation.
+
+        NOTE: This is a minimal implementation that keeps identity mapping for Phase 0.
+        Future work will implement canonical HF name mapping and save/restore mapping.
+        """
+
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.exec_ft_phase = partial(StrategyAdapter.base_ft_phase, translation_func=self.logical_param_translation)
+
+        def logical_param_translation(self, param_names: List[str]) -> List[str]:
+            return param_names
+
+        def fts_optim_transform(self, orig_pl: List[str], inspect_only: bool = False) -> List[str]:
+            return orig_pl
+
+        def before_restore_model(self, checkpoint: Dict[str, Any]) -> Dict[str, Any]:
+            """Prepare checkpoint for TransformerBridge restoration.
+
+            TransformerBridge creates multiple parameter aliases:
+            1. Original HF keys: model.transformer.*
+            2. TL-style aliases: model.blocks.*, model.embed, etc.
+            3. Prefixed HF keys: model.original_model.transformer.*
+
+            Checkpoints only contain the original HF keys. We need to duplicate them with the
+            additional naming patterns so all named_parameters can find their values.
+            """
+            state_dict = checkpoint.get("state_dict", {})
+            if not state_dict:
+                return checkpoint
+
+            rank_zero_info(
+                "TransformerBridgeStrategyAdapter: Expanding checkpoint keys for TransformerBridge aliases..."
+            )
+
+            expanded_state_dict = {}
+
+            for key, value in state_dict.items():
+                # Skip direct HF keys - we only want the aliased versions
+                # (The original model.transformer.* and model.lm_head.* keys should not be in expanded dict)
+
+                # Add original_model prefix for HF keys
+                if key.startswith("model.transformer."):
+                    original_model_key = key.replace("model.transformer.", "model.original_model.transformer.", 1)
+                    expanded_state_dict[original_model_key] = value
+                elif key.startswith("model.lm_head."):
+                    original_model_key = key.replace("model.lm_head.", "model.original_model.lm_head.", 1)
+                    expanded_state_dict[original_model_key] = value
+                else:
+                    # Keep non-model keys as-is (like optimizer states, etc.)
+                    expanded_state_dict[key] = value
+
+                # Add TL-style alias keys
+                # model.transformer.wte -> model.embed
+                if ".transformer.wte." in key:
+                    tl_key = key.replace(".transformer.wte.", ".embed.")
+                    expanded_state_dict[tl_key] = value
+                # model.transformer.wpe -> model.pos_embed
+                elif ".transformer.wpe." in key:
+                    tl_key = key.replace(".transformer.wpe.", ".pos_embed.")
+                    expanded_state_dict[tl_key] = value
+                # model.transformer.h.N -> model.blocks.N
+                elif ".transformer.h." in key:
+                    tl_key = key.replace(".transformer.h.", ".blocks.")
+                    expanded_state_dict[tl_key] = value
+                # model.transformer.ln_f -> model.ln_final
+                elif ".transformer.ln_f." in key:
+                    tl_key = key.replace(".transformer.ln_f.", ".ln_final.")
+                    expanded_state_dict[tl_key] = value
+                # model.lm_head -> model.unembed
+                elif ".lm_head." in key:
+                    tl_key = key.replace(".lm_head.", ".unembed.")
+                    expanded_state_dict[tl_key] = value
+
+            checkpoint["state_dict"] = expanded_state_dict
+            rank_zero_info(f"Expanded {len(state_dict)} keys to {len(expanded_state_dict)} keys with aliases")
+
+            return checkpoint
+
+else:
+    TransformerBridgeStrategyAdapter = object

--- a/src/interpretune/adapters/transformer_lens.py
+++ b/src/interpretune/adapters/transformer_lens.py
@@ -263,9 +263,10 @@ class BaseITLensModule(BaseITModule):
         # Debug shim: log component mapping for troubleshooting checkpoint restoration
         if hasattr(adapter, "component_mapping"):
             component_mapping = adapter.component_mapping
-            hf_prefixes = {getattr(c, "name", "?").split(".")[0] for c in component_mapping.values()}
-            rank_zero_debug(f"TransformerBridge component_mapping keys: {list(component_mapping.keys())}")
-            rank_zero_debug(f"TransformerBridge HF top-level prefixes: {hf_prefixes}")
+            if component_mapping is not None:
+                hf_prefixes = {getattr(c, "name", "?").split(".")[0] for c in component_mapping.values()}
+                rank_zero_debug(f"TransformerBridge component_mapping keys: {list(component_mapping.keys())}")
+                rank_zero_debug(f"TransformerBridge HF top-level prefixes: {hf_prefixes}")
 
         # Enable compatibility mode if requested (ITLensBridgeConfig only)
         if isinstance(self.it_cfg.tl_cfg, ITLensBridgeConfig) and self.it_cfg.tl_cfg.enable_compatibility_mode:
@@ -456,13 +457,15 @@ if _FTS_AVAILABLE:
                 self.model_view = CanonicalModelView(self, **self._model_view_cfg)
 
             # Build parameter mapping
+            assert self.model_view is not None
             self.model_view.build_param_mapping()
 
         def on_before_init_fts(self) -> None:
             # we patch our wrapped TransformerBridge module to use the TransformerBridge's state_dict and
             # load_state_dict methods to handle the specialized key translation logic
-            setattr(self.pl_module, "state_dict", self.pl_module.model.state_dict)
-            setattr(self.pl_module, "load_state_dict", self.pl_module.model.load_state_dict)
+            assert self.pl_module is not None
+            setattr(self.pl_module, "state_dict", self.pl_module.model.state_dict)  # type: ignore[attr-defined]
+            setattr(self.pl_module, "load_state_dict", self.pl_module.model.load_state_dict)  # type: ignore[attr-defined]
 
             # Ensure model_view is initialized (may already be initialized if gen_ft_sched_only=True)
             self._ensure_model_view_initialized()
@@ -479,6 +482,7 @@ if _FTS_AVAILABLE:
             Returns:
                 List of canonical parameter names for optimizer
             """
+            assert self.model_view is not None
             return self.model_view.transform_to_canonical(orig_pl, inspect_only=inspect_only)
 
         def logical_param_translation(self, param_names: List[str]) -> List[str]:
@@ -492,18 +496,20 @@ if _FTS_AVAILABLE:
             Returns:
                 List of model view parameter names
             """
+            assert self.model_view is not None
             return self.model_view.transform_from_canonical(param_names)
 
-        def get_named_params_for_schedule_validation(self) -> Dict[str, torch.Tensor]:
+        def get_named_params_for_schedule_validation(self) -> Dict[str, torch.nn.Parameter]:
             """Get named parameters for schedule validation.
 
             Delegates to the active model view for parameter naming.
 
             Returns:
-                Dict[str, torch.Tensor]: A dictionary mapping parameter names to parameter tensors.
+                Dict[str, torch.nn.Parameter]: A dictionary mapping parameter names to parameter tensors.
             """
             self._ensure_model_view_initialized()
-            return self.model_view.get_named_params()
+            assert self.model_view is not None
+            return self.model_view.get_named_params()  # type: ignore[return-value]
 
         def validate_ft_sched(self) -> Tuple[int, int]:
             """Validate the fine-tuning schedule.
@@ -521,6 +527,7 @@ if _FTS_AVAILABLE:
                 f"for schedule validation (module: {self.pl_module.__class__.__name__})"
             )
             # Delegate to model view's validation (which calls base StrategyAdapter implementation)
+            assert self.model_view is not None
             return self.model_view.validate_schedule()
 
         def gen_ft_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
@@ -539,6 +546,7 @@ if _FTS_AVAILABLE:
                 f"[TransformerBridgeStrategyAdapter.gen_ft_schedule] Using {self.model_view.__class__.__name__} "
                 f"for schedule generation (module: {self.pl_module.__class__.__name__})"
             )
+            assert self.model_view is not None
             return self.model_view.gen_schedule(dump_loc)
 
         def lightning_module_state_dict(self) -> dict[str, Any]:
@@ -548,11 +556,11 @@ if _FTS_AVAILABLE:
                 and hasattr(self.pl_module, "model")
                 and hasattr(self.pl_module.model, "state_dict")
             )
-            return self.pl_module.model.state_dict()
+            return self.pl_module.model.state_dict()  # type: ignore[attr-defined,no-any-return]
 
         def load_model_state_dict(self, checkpoint: Mapping[str, Any], strict: bool = True) -> None:
             assert self.pl_module is not None
-            self.pl_module.model.load_state_dict(checkpoint["state_dict"], strict=strict)
+            self.pl_module.model.load_state_dict(checkpoint["state_dict"], strict=strict)  # type: ignore[attr-defined]
 
     class TLNamesModelView(ModelView):
         """TransformerLens-style parameter naming strategy.
@@ -603,7 +611,7 @@ if _FTS_AVAILABLE:
             bridge = self.pl_module.model
 
             # Get TL-style parameter names (source of truth for TL naming)
-            tl_params = dict(bridge.tl_named_parameters())
+            tl_params = dict(bridge.tl_named_parameters())  # type: ignore[attr-defined]
 
             # Get canonical parameters
             canonical_params = dict(self.pl_module.named_parameters())
@@ -764,7 +772,7 @@ if _FTS_AVAILABLE:
             Returns:
                 Dict[str, torch.Tensor]: A dictionary mapping TL-style names to parameter tensors.
             """
-            return dict(self.pl_module.model.tl_named_parameters())
+            return dict(self.pl_module.model.tl_named_parameters())  # type: ignore[attr-defined]
 
         def gen_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
             """Generate fine-tuning schedule using TL-style parameter names.
@@ -787,7 +795,7 @@ if _FTS_AVAILABLE:
             cur_group: List = []
 
             # Use TL-style parameter names
-            model_params = list(self.pl_module.model.tl_named_parameters())[::-1]
+            model_params = list(self.pl_module.model.tl_named_parameters())[::-1]  # type: ignore[attr-defined]
 
             # Apply 2-parameters per-level heuristic
             for i, (n, _) in enumerate(model_params):
@@ -823,7 +831,7 @@ if _FTS_AVAILABLE:
                     2. The maximum epoch watermark explicitly specified in the schedule
             """
             rank_zero_debug("TLNamesModelView.validate_schedule() called")
-            if self._tl_to_canonical_mapping is not None:
+            if self._tl_to_canonical_mapping is not None and self._canonical_to_tl_mapping is not None:
                 # Log mapping diagnostics for debugging
                 rank_zero_debug(
                     f"TL-style schedule validation - TL→Canonical mapping summary:\n"
@@ -1043,5 +1051,5 @@ if _FTS_AVAILABLE:
             return implicit_ln_params
 
 else:
-    TransformerBridgeStrategyAdapter = object
-    TLNamesModelView = object
+    TransformerBridgeStrategyAdapter = object  # type: ignore[misc,assignment]
+    TLNamesModelView = object  # type: ignore[misc,assignment]

--- a/src/interpretune/base/components/core.py
+++ b/src/interpretune/base/components/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import tempfile
 import warnings
+import logging
 from datetime import datetime
 from typing import Any, Union, TYPE_CHECKING, cast, Optional
 from functools import reduce, partial
@@ -84,7 +85,26 @@ class BaseConfigImpl:
                 )
         return serial_cfg
 
+    def _configure_logging(self) -> None:
+        """Configure logging level for Interpretune loggers."""
+        log_level = self.it_cfg.logging_level
+        if isinstance(log_level, str):
+            log_level = getattr(logging, log_level.upper(), logging.INFO)
+
+        # Set level for main interpretune logger and key submodules
+        for logger_name in ["interpretune", "interpretune.adapters", "interpretune.base"]:
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(log_level)
+            # Also ensure handlers exist and are configured
+            if not logger.handlers:
+                handler = logging.StreamHandler()
+                handler.setLevel(log_level)
+                formatter = logging.Formatter("[%(levelname)s] %(name)s: %(message)s")
+                handler.setFormatter(formatter)
+                logger.addHandler(handler)
+
     def _init_dirs_and_hooks(self) -> None:
+        self._configure_logging()
         self._create_experiment_dir()
         if self.cuda_allocator_history:
             self.memprofiler.init_cuda_snapshots_dir()

--- a/src/interpretune/base/components/core.py
+++ b/src/interpretune/base/components/core.py
@@ -97,8 +97,8 @@ class BaseConfigImpl:
             logger.removeHandler(existing_stream)
             try:
                 existing_stream.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                rank_zero_debug("Failed to close existing stream handler: %s", exc)
 
     def _existing_file_handler_matches(
         self, existing_files: list[logging.FileHandler], logger_name: str, log_file: Path

--- a/src/interpretune/base/components/core.py
+++ b/src/interpretune/base/components/core.py
@@ -85,6 +85,74 @@ class BaseConfigImpl:
                 )
         return serial_cfg
 
+    def _setup_stream_handler(self, logger: logging.Logger, formatter: logging.Formatter, level: int) -> None:
+        """Ensure stream handler presence/absence per config."""
+        existing_stream = next((h for h in logger.handlers if isinstance(h, logging.StreamHandler)), None)
+        if self.it_cfg.log_to_stream and existing_stream is None:
+            stream_handler = logging.StreamHandler()
+            stream_handler.setLevel(level)
+            stream_handler.setFormatter(formatter)
+            logger.addHandler(stream_handler)
+        elif not self.it_cfg.log_to_stream and existing_stream is not None:
+            logger.removeHandler(existing_stream)
+            try:
+                existing_stream.close()
+            except Exception:
+                pass
+
+    def _existing_file_handler_matches(
+        self, existing_files: list[logging.FileHandler], logger_name: str, log_file: Path
+    ) -> bool:
+        """Return True if any existing FileHandler already points to log_file. Logs debug messages for other cases."""
+        matched = False
+        for existing_file in existing_files:
+            try:
+                existing_path = getattr(existing_file, "baseFilename", None)
+            except Exception:
+                existing_path = None
+
+            if existing_path is None:
+                rank_zero_debug(
+                    "Existing file handler for logger %s has unknown path; keeping existing handler "
+                    "and still creating %s if not present.",
+                    logger_name,
+                    log_file,
+                )
+            elif Path(existing_path) == log_file:
+                matched = True
+                break
+            else:
+                rank_zero_debug(
+                    "Existing file handler for logger %s points to %s; will keep it and also create handler at %s.",
+                    logger_name,
+                    existing_path,
+                    log_file,
+                )
+        return matched
+
+    def _setup_file_handler(
+        self, logger_name: str, logger: logging.Logger, formatter: logging.Formatter, level: int
+    ) -> None:
+        """Attach a FileHandler to logger if requested, preserving existing handlers when appropriate."""
+        existing_files = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+
+        target_log_dir = None
+        core_ld = getattr(self.it_cfg, "core_log_dir", None)
+        if core_ld is not None:
+            target_log_dir = Path(core_ld)
+        elif getattr(self, "_it_state", None) and getattr(self._it_state, "_log_dir", None):
+            target_log_dir = Path(self._it_state._log_dir)
+
+        if self.it_cfg.log_to_file and target_log_dir is not None:
+            target_log_dir.mkdir(exist_ok=True, parents=True)
+            log_file = target_log_dir / f"{logger_name.replace('.', '_')}.log"
+            matched = self._existing_file_handler_matches(existing_files, logger_name, log_file)
+            if not matched:
+                file_handler = logging.FileHandler(log_file, mode="a")
+                file_handler.setLevel(level)
+                file_handler.setFormatter(formatter)
+                logger.addHandler(file_handler)
+
     def _configure_logging(self) -> None:
         """Configure logging level for Interpretune loggers."""
         log_level = self.it_cfg.logging_level
@@ -92,25 +160,46 @@ class BaseConfigImpl:
             log_level = getattr(logging, log_level.upper(), logging.INFO)
 
         # Set level for main interpretune logger and key submodules
-        for logger_name in ["interpretune", "interpretune.adapters", "interpretune.base"]:
+        for logger_name in ["interpretune"]:
             logger = logging.getLogger(logger_name)
             logger.setLevel(log_level)
-            # Also ensure handlers exist and are configured
-            if not logger.handlers:
-                handler = logging.StreamHandler()
-                handler.setLevel(log_level)
-                formatter = logging.Formatter("[%(levelname)s] %(name)s: %(message)s")
-                handler.setFormatter(formatter)
-                logger.addHandler(handler)
 
-    def _init_dirs_and_hooks(self) -> None:
-        self._configure_logging()
-        self._create_experiment_dir()
+            formatter = logging.Formatter("[%(levelname)s] %(name)s: %(message)s")
+
+            # Stream handler: ensure presence when configured
+            self._setup_stream_handler(logger, formatter, log_level)
+
+            # File handler: attach to core_log_dir if set in config, otherwise fall back to runtime _log_dir
+            self._setup_file_handler(logger_name, logger, formatter, log_level)
+
+    def _make_setup_dirs(self) -> None:
+        """Create minimal setup directories."""
         if self.cuda_allocator_history:
             self.memprofiler.init_cuda_snapshots_dir()
         # TODO: add save_hyperparameters/basic logging func for raw pytorch
         # (override w/ a framework-specific version where appropriate)
         # self.save_hyperparameters(self._it_state._init_hparams)
+
+    def _init_experiment_id(self) -> None:
+        """Initialize experiment_id early in the lifecycle, before directory creation.
+
+        This must be called before _create_experiment_dir() which needs the experiment_id.
+        """
+        if "experiment_id" not in self._it_state._init_hparams:
+            self._it_state._init_hparams["experiment_id"] = (
+                f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{self.it_cfg.experiment_tag}"
+            )
+
+    def _make_init_dirs(self) -> None:
+        """Create experiment-scoped directories and configure logging. This should be called when the
+        runtime experiment directory (and therefore the per-run log dir) is available (e.g., after fixture/trainer
+        setup)."""
+        # Ensure experiment_id exists before creating directories
+        self._init_experiment_id()
+        # Create the experiment dir first so that log directory exists
+        self._create_experiment_dir()
+        # Now configure logging to attach file handlers into the experiment directory if requested
+        self._configure_logging()
 
     def _create_experiment_dir(self) -> None:
         # we only want to create the core experiment-specific dir for frameworks that aren't adding their own
@@ -137,6 +226,10 @@ class BaseConfigImpl:
         #       case (self.model.config) or self.it_cfg.model_cfg
         elif getattr(self.model, "config", None) is None:
             model_config = self.it_cfg.model_cfg
+
+        # Ensure experiment_id is initialized (may have been set earlier by _init_experiment_id)
+        self._init_experiment_id()
+
         self._it_state._init_hparams.update(
             {
                 "optimizer_init": self.it_cfg.optimizer_init,
@@ -146,7 +239,6 @@ class BaseConfigImpl:
                 "model_config": model_config,
                 "model_name_or_path": self.it_cfg.model_name_or_path,
                 "task_name": self.it_cfg.task_name,
-                "experiment_id": f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{self.it_cfg.experiment_tag}",
             }
         )
         self._it_state._init_hparams["env_info"] = collect_env_info() if self.it_cfg.log_env_details else None

--- a/src/interpretune/base/components/core.py
+++ b/src/interpretune/base/components/core.py
@@ -141,7 +141,9 @@ class BaseConfigImpl:
         if core_ld is not None:
             target_log_dir = Path(core_ld)
         elif getattr(self, "_it_state", None) and getattr(self._it_state, "_log_dir", None):
-            target_log_dir = Path(self._it_state._log_dir)
+            log_dir = self._it_state._log_dir
+            if log_dir is not None:
+                target_log_dir = Path(log_dir)
 
         if self.it_cfg.log_to_file and target_log_dir is not None:
             target_log_dir.mkdir(exist_ok=True, parents=True)

--- a/src/interpretune/base/hooks.py
+++ b/src/interpretune/base/hooks.py
@@ -26,7 +26,7 @@ class BaseITHooks:
         # for some adapters, datamodule access is not provided in setup and will be accessed via Trainer
         if datamodule := kwargs.get("datamodule", None):
             self._it_state._datamodule = datamodule
-        self._init_dirs_and_hooks()  # type: ignore[attr-defined]  # provided by mixin composition
+        self._make_setup_dirs()  # type: ignore[attr-defined]  # provided by mixin composition
         if self.it_cfg.classification_mapping is not None:
             self.init_classification_mapping()  # type: ignore[attr-defined]  # provided by mixin composition
 

--- a/src/interpretune/base/hooks.py
+++ b/src/interpretune/base/hooks.py
@@ -33,10 +33,6 @@ class BaseITHooks:
     def configure_optimizers(self) -> OptimizerLRScheduler | None:
         """Optional because it is not mandatory in the context of core IT modules (required for some adapter
         modules)."""
-        # With FTS >= 2.0, ``FinetuningScheduler`` simplifies initial optimizer configuration by ensuring the optimizer
-        # configured here will optimize the parameters (and only those parameters) scheduled to be optimized in phase 0
-        # of the current fine-tuning schedule. This auto-configuration can be disabled if desired by setting
-        # ``enforce_phase0_params`` to ``False``.
         self.set_input_require_grads()  # type: ignore[attr-defined]  # provided by mixin composition
         optimizer, scheduler = None, None
         if self.it_cfg.optimizer_init:  # in case this hook is manually invoked by the user

--- a/src/interpretune/base/modules.py
+++ b/src/interpretune/base/modules.py
@@ -17,6 +17,7 @@ class BaseITModule(BaseITMixins, BaseITComponents, BaseITHooks, torch.nn.Module)
         super().__init__(*args, **kwargs)
         self.model: torch.nn.Module = None  # type: ignore[assignment]  # initialized later in lifecycle
         self.it_cfg: ITConfig = self._before_it_cfg_init(it_cfg)
+        self._make_init_dirs()
         self._connect_extensions()
         self._dispatch_model_init()
 

--- a/src/interpretune/config/__init__.py
+++ b/src/interpretune/config/__init__.py
@@ -16,6 +16,7 @@ from interpretune.config.mixins import (
 )
 from interpretune.config.module import ITConfig, ITState
 from interpretune.config.transformer_lens import (
+    ITLensBridgeConfig,
     ITLensConfig,
     ITLensCustomConfig,
     ITLensFromPretrainedConfig,
@@ -71,6 +72,7 @@ __all__ = [
     "ITConfig",
     "ITState",
     # from interpretune.config.transformer_lens
+    "ITLensBridgeConfig",
     "ITLensConfig",
     "ITLensCustomConfig",
     "ITLensFromPretrainedConfig",

--- a/src/interpretune/config/module.py
+++ b/src/interpretune/config/module.py
@@ -66,6 +66,7 @@ class LoggingConf(ITSerializableCfg):
     experiment_tag: str | None = "default"
     log_env_details: bool | None = True
     core_log_dir: StrOrPath | None = None
+    logging_level: str | int = "INFO"
 
 
 @dataclass(kw_only=True)

--- a/src/interpretune/config/module.py
+++ b/src/interpretune/config/module.py
@@ -67,6 +67,8 @@ class LoggingConf(ITSerializableCfg):
     log_env_details: bool | None = True
     core_log_dir: StrOrPath | None = None
     logging_level: str | int = "INFO"
+    log_to_stream: bool = True
+    log_to_file: bool = True
 
 
 @dataclass(kw_only=True)

--- a/src/interpretune/config/transformer_lens.py
+++ b/src/interpretune/config/transformer_lens.py
@@ -24,6 +24,79 @@ class ITLensSharedConfig(ITSerializableCfg):
     use_bridge: Optional[bool] = True  # Use TransformerBridge (v3) by default, set False for legacy HookedTransformer
 
 
+@dataclass(kw_only=True)
+class ITLensBridgeConfig(ITLensSharedConfig):
+    """TransformerBridge-specific configuration for TransformerLens v3 integration.
+
+    This config provides explicit control over TransformerBridge initialization and
+    compatibility mode settings. Use this config when you need fine-grained control
+    over how the bridge is configured (e.g., enabling/disabling weight processing).
+
+    Args:
+        model_name: The model name for TransformerBridge (passed to TransformerBridgeConfig).
+        transformer_bridge_config_overrides: Optional dict of kwargs to pass to/override
+            in the TransformerBridgeConfig constructor. Use this to set device, dtype,
+            or any other TransformerBridgeConfig fields.
+        enable_compatibility_mode: Whether to call enable_compatibility_mode() on the
+            TransformerBridge after instantiation. Default: False.
+        enable_compatibility_mode_kwargs: Optional dict of kwargs for enable_compatibility_mode().
+            Supported kwargs:
+            - disable_warnings: bool (default False)
+            - no_processing: bool (default False) - disables ALL weight processing
+            - fold_ln: bool (default True) - fold LayerNorm weights
+            - center_writing_weights: bool (default True)
+            - center_unembed: bool (default True)
+            - fold_value_biases: bool (default True)
+            - refactor_factored_attn_matrices: bool (default False)
+
+    Example:
+        # Basic bridge config (no processing, current default behavior)
+        config = ITLensBridgeConfig(model_name="gpt2-small")
+
+        # Enable weight processing via compatibility mode
+        config = ITLensBridgeConfig(
+            model_name="gpt2-small",
+            enable_compatibility_mode=True,
+            enable_compatibility_mode_kwargs={"fold_ln": True, "fold_value_biases": True}
+        )
+
+        # Use no_processing (analogous to ITLensFromPretrainedNoProcessingConfig behavior)
+        config = ITLensBridgeConfig(
+            model_name="gpt2-small",
+            enable_compatibility_mode=True,
+            enable_compatibility_mode_kwargs={"no_processing": True}
+        )
+    """
+
+    # The model name/path for TransformerBridge - IT handles HF model instantiation via model_name_or_path
+    model_name: str = "gpt2-small"
+    # Optional kwargs to pass to TransformerBridgeConfig constructor
+    transformer_bridge_config_overrides: Optional[Dict[str, Any]] = None
+    # Whether to call enable_compatibility_mode on the bridge after instantiation
+    # N.B.: See transformer_lens/model_bridge/bridge.py for details, among other things, this mode:
+    # 1. Breaks weight tying between embed and unembed to allow separate unembed centering
+    # 2. Extracts q/k/v from joint qkv matrices for compatibility with HookedTransformer parameterizations
+    enable_compatibility_mode: bool = False
+    # Optional kwargs for enable_compatibility_mode()
+    enable_compatibility_mode_kwargs: Optional[Dict[str, Any]] = None
+    # Bridge config defaults to using bridge
+    use_bridge: Optional[bool] = True
+    # Device is commonly set, so we provide a top-level field for convenience
+    device: Optional[str] = None
+    # Dtype is commonly set, so we provide a top-level field for convenience
+    dtype: str = "float32"
+
+    def __post_init__(self) -> None:
+        if self.device is None:  # align with TL default device resolution
+            self.device = tl_get_device()  # type: ignore
+        # Validate that enable_compatibility_mode_kwargs are only set when enable_compatibility_mode is True
+        if self.enable_compatibility_mode_kwargs and not self.enable_compatibility_mode:
+            rank_zero_warn(
+                "enable_compatibility_mode_kwargs was provided but enable_compatibility_mode is False. "
+                "The kwargs will be ignored. Set enable_compatibility_mode=True to use them."
+            )
+
+
 # TODO: open a PR to have TL `from_pretrained` config encapsulated in a dataclass for improved external compatibility
 @dataclass(kw_only=True)
 class ITLensFromPretrainedConfig(ITLensSharedConfig):
@@ -86,24 +159,29 @@ class ITLensCustomConfig(ITLensSharedConfig):
             self.cfg = HookedTransformerConfig.from_dict(self.cfg)
 
 
-ITLensCfg: TypeAlias = ITLensFromPretrainedConfig | ITLensCustomConfig  # for static typing
-ITLensCfgTypes: Tuple[type, type] = (ITLensFromPretrainedConfig, ITLensCustomConfig)  # for runtime checks
+ITLensCfg: TypeAlias = ITLensFromPretrainedConfig | ITLensCustomConfig | ITLensBridgeConfig  # for static typing
+ITLensCfgTypes: Tuple[type, type, type] = (
+    ITLensFromPretrainedConfig,
+    ITLensCustomConfig,
+    ITLensBridgeConfig,
+)  # for runtime checks
 
 
 @dataclass(kw_only=True)
 class ITLensConfig(ITConfig):
-    """Dataclass to encapsulate the ITModuleinternal state."""
+    """Dataclass to encapsulate the ITModule internal state."""
 
-    tl_cfg: ITLensFromPretrainedConfig | ITLensCustomConfig
+    tl_cfg: ITLensFromPretrainedConfig | ITLensCustomConfig | ITLensBridgeConfig
 
     def __post_init__(self) -> None:
         if not self.tl_cfg:
             raise MisconfigurationException(
-                "Either a `ITLensFromPretrainedConfig` or `ITLensCustomConfig` must be"
-                " provided to initialize a HookedTransformer and use TransformerLens."
+                "A valid tl_cfg (ITLensFromPretrainedConfig, ITLensCustomConfig, or ITLensBridgeConfig) must be"
+                " provided to initialize a HookedTransformer/TransformerBridge and use TransformerLens."
             )
         # internal variable used to bootstrap model initialization mode (we may need to override hf_from_pretrained_cfg)
-        self._load_from_pretrained = False if isinstance(self.tl_cfg, ITLensCustomConfig) else True
+        # ITLensBridgeConfig is a pretrained mode config (like ITLensFromPretrainedConfig)
+        self._load_from_pretrained = not isinstance(self.tl_cfg, ITLensCustomConfig)
         if not self._load_from_pretrained:
             # If a custom config was provided, TransformerBridge (v3) cannot be used because it requires an HF model.
             # Default to legacy HookedTransformer (use_bridge=False) for custom configs. If the user explicitly
@@ -141,7 +219,9 @@ class ITLensConfig(ITConfig):
         qual_sub_key = tl_cfg_key.split(".")
         fallback_val = reduce(getattr, qual_sub_key, self)
         if fallback_val not in [None, "custom"]:
-            if getattr(self, target_key, None) is not None:
+            existing_val = getattr(self, target_key, None)
+            # Treat both None and empty string as "not provided"
+            if existing_val is not None and existing_val != "":
                 hf_override_msg = f"Since `{target_key}` was provided, `{tl_cfg_key}` will be ignored."
             else:
                 hf_override_msg = (
@@ -157,8 +237,14 @@ class ITLensConfig(ITConfig):
     def _translate_tl_config(self):
         # TODO: driving this fallback mapping from a dict
         if self._load_from_pretrained:
-            self._map_tl_fallback(target_key="model_name_or_path", tl_cfg_key="tl_cfg.hf_model")
-            self._map_tl_fallback(target_key="tokenizer", tl_cfg_key="tl_cfg.tokenizer")
+            # Only ITLensFromPretrainedConfig and variants have an `hf_model` field that maps to model_name_or_path,
+            # ITLensBridgeConfig natively uses `model_name` for HF model instantiation (TL registry aliases for models
+            # have been deprecated in favor of HF model names/paths for bridge mode).
+            if hasattr(self.tl_cfg, "hf_model"):
+                self._map_tl_fallback(target_key="model_name_or_path", tl_cfg_key="tl_cfg.hf_model")
+            # Only ITLensFromPretrainedConfig has tokenizer field; ITLensBridgeConfig doesn't have it
+            if hasattr(self.tl_cfg, "tokenizer"):
+                self._map_tl_fallback(target_key="tokenizer", tl_cfg_key="tl_cfg.tokenizer")
         else:
             self._map_tl_fallback(target_key="model_name_or_path", tl_cfg_key="tl_cfg.cfg.model_name")
             self._map_tl_fallback(target_key="tokenizer_name", tl_cfg_key="tl_cfg.cfg.tokenizer_name")
@@ -180,7 +266,8 @@ class ITLensConfig(ITConfig):
             self._check_supported_device_map()
             if hf_dtype := self.hf_from_pretrained_cfg.pretrained_kwargs.get("dtype", None):
                 hf_dtype = _resolve_dtype(hf_dtype)
-            assert isinstance(self.tl_cfg, ITLensFromPretrainedConfig)
+            # Both ITLensFromPretrainedConfig and ITLensBridgeConfig have dtype attribute
+            assert isinstance(self.tl_cfg, (ITLensFromPretrainedConfig, ITLensBridgeConfig))
             tl_dtype = _resolve_dtype(self.tl_cfg.dtype)
             self._sync_hf_tl_dtypes(hf_dtype, tl_dtype)
 

--- a/src/it_examples/example_module_registry.yaml
+++ b/src/it_examples/example_module_registry.yaml
@@ -521,6 +521,67 @@ gemma2.rte.sae_lens:
             release: gemma-scope-2b-pt-res-canonical
             sae_id: layer_25/width_16k/canonical
             device: cuda
+gemma2.rte.transformer_lens:
+  reg_info:
+    model_src_key: gemma2
+    task_name: rte
+    adapter_combinations:
+      - [core, transformer_lens]
+      - [lightning, transformer_lens]
+    description: Basic Transformer Lens example, Gemma2-2b (non-instruction tuned) with supported adapter compositions
+  shared_config:
+    task_name: rte
+    os_env_model_auth_key: HF_GATED_PUBLIC_REPO_AUTH_KEY
+    model_name_or_path: google/gemma-2-2b
+    tokenizer_kwargs:
+        model_input_names: ['input']
+        padding_side: left
+        add_bos_token: true
+  registered_cfg:
+    datamodule_cfg:
+      prompt_cfg:
+        class_path: it_examples.experiments.rte_boolq.RTEBoolqPromptConfig
+      signature_columns: ['input', 'labels']
+      text_fields: ["premise", "hypothesis"]
+      enable_datasets_cache: False
+      train_batch_size: 2
+      eval_batch_size: 2
+    module_cfg:
+      class_path: interpretune.config.module.ITConfig
+      init_args:
+        auto_comp_cfg:
+          class_path: interpretune.config.shared.AutoCompConfig
+          init_args:
+            module_cfg_name: RTEBoolqConfig
+            module_cfg_mixin:
+              class_path: it_examples.experiments.rte_boolq.RTEBoolqEntailmentMapping
+              import_only: True
+        generative_step_cfg:
+          class_path: it_examples.experiments.rte_boolq.RTEBoolqGenerativeClassificationConfig
+          init_args:
+            enabled: True
+            lm_generation_cfg:
+              class_path: interpretune.config.transformer_lens.TLensGenerationConfig
+              init_args:
+                max_new_tokens: 1
+                output_logits: true
+                return_dict_in_generate: true
+        hf_from_pretrained_cfg:
+          class_path: interpretune.config.mixins.HFFromPretrainedConfig
+          init_args:
+            pretrained_kwargs:
+              device_map: cpu
+              dtype: float32
+            model_head: transformers.Gemma2ForCausalLM
+        tl_cfg:
+          class_path: interpretune.config.transformer_lens.ITLensBridgeConfig
+          init_args:
+            model_name: gemma-2-2b
+            default_padding_side: left  # to pad on left
+    datamodule_cls:
+      class_path: tests.modules.FingerprintTestITDataModule
+    module_cls:
+      class_path: tests.modules.TestITModule
 gemma2.rte_demo.circuit_tracer:
   reg_info:
     model_src_key: gemma2
@@ -752,3 +813,82 @@ llama3.rte:
               lora_dropout: 0.05
               bias: none
               task_type: "CAUSAL_LM"
+llama3.rte.transformer_lens:
+  reg_info:
+    model_src_key: llama3
+    task_name: rte
+    adapter_combinations:
+      - [core, transformer_lens]
+      - [lightning, transformer_lens]
+    description: Basic example, Llama3 with supported adapter compositions
+  shared_config:
+    task_name: pytest_rte_hf
+    os_env_model_auth_key: HF_GATED_PUBLIC_REPO_AUTH_KEY
+    model_name_or_path: meta-llama/Llama-3.2-3B-Instruct
+    tokenizer_id_overrides:
+      pad_token_id: 128004
+    tokenizer_kwargs:
+        model_input_names: ['input_ids', 'attention_mask']
+        # NOTE: this configuration is for testing, for finetuning, llama3 should be changed to right padding
+        padding_side: left
+        add_bos_token: false
+  registered_cfg:
+    datamodule_cfg:
+      prompt_cfg:
+        class_path: it_examples.example_prompt_configs.RTEBoolqLlama3PromptConfig
+      signature_columns: ['input_ids', 'attention_mask', 'labels']
+      text_fields: ["premise", "hypothesis"]
+      enable_datasets_cache: True
+      train_batch_size: 2
+      eval_batch_size: 2
+      special_tokens_dict: {"pad_token": "<|finetune_right_pad_id|>"}
+      cust_tokenization_pattern: llama3-chat
+    module_cfg:
+      class_path: interpretune.config.module.ITConfig
+      init_args:
+        auto_comp_cfg:
+          class_path: interpretune.config.shared.AutoCompConfig
+          init_args:
+            module_cfg_name: RTEBoolqConfig
+            module_cfg_mixin:
+              class_path: it_examples.experiments.rte_boolq.RTEBoolqEntailmentMapping
+              import_only: True
+        generative_step_cfg:
+          class_path: it_examples.experiments.rte_boolq.RTEBoolqGenerativeClassificationConfig
+          init_args:
+            enabled: True
+            lm_generation_cfg:
+              class_path: interpretune.config.transformer_lens.TLensGenerationConfig
+              init_args:
+                max_new_tokens: 1
+                output_logits: true
+                return_dict_in_generate: true
+        tl_cfg:
+          class_path: interpretune.config.transformer_lens.ITLensBridgeConfig
+          init_args:
+            model_name: Llama-3.2-3B-Instruct
+            default_padding_side: left  # to pad on left
+        hf_from_pretrained_cfg:
+          class_path: interpretune.config.mixins.HFFromPretrainedConfig
+          init_args:
+            use_model_cache: false
+            pretrained_kwargs:
+              device_map: cpu
+              dtype: float32
+            model_head: transformers.LlamaForCausalLM
+            bitsandbytesconfig:
+              load_in_4bit: True
+              bnb_4bit_use_double_quant: True
+              bnb_4bit_quant_type: nf4
+              bnb_4bit_compute_dtype: bfloat16
+            lora_cfg:
+              r: 8
+              lora_alpha: 32
+              target_modules: ["q_proj", "v_proj"]
+              lora_dropout: 0.05
+              bias: none
+              task_type: "CAUSAL_LM"
+    datamodule_cls:
+      class_path: tests.modules.FingerprintTestITDataModule
+    module_cls:
+      class_path: tests.modules.TestITModule

--- a/tests/base_defaults.py
+++ b/tests/base_defaults.py
@@ -74,6 +74,8 @@ class BaseCfg:
     precision: str | int = "torch.float32"
     adapter_ctx: Sequence[Adapter | str] = (Adapter.core,)
     model_src_key: Optional[str] = None
+    datamodule_cls: Optional[str] = None  # Fully qualified class name (e.g., "tests.modules.DivergeTestITModule")
+    module_cls: Optional[str] = None  # Fully qualified class name (e.g., "tests.modules.DivergeTestITModule")
     limit_train_batches: Optional[int] = 1
     limit_val_batches: Optional[int] = 1
     limit_test_batches: Optional[int] = 1

--- a/tests/base_defaults.py
+++ b/tests/base_defaults.py
@@ -95,6 +95,7 @@ class BaseCfg:
     max_steps: Optional[int] = None
     save_checkpoints: bool = False
     req_deterministic: bool = False
+    logging_level: str | int = "INFO"  # Logging level for test runs
 
     def __post_init__(self):
         self.adapter_ctx = ADAPTER_REGISTRY.canonicalize_composition(self.adapter_ctx)

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -25,6 +25,7 @@ from interpretune.config import (
     AnalysisCfg,
     SAELensFromPretrainedConfig,
     SAELensCustomConfig,
+    ITLensBridgeConfig,
     ITLensFromPretrainedConfig,
     ITLensCustomConfig,
 )
@@ -111,8 +112,8 @@ def _update_tl_cfg_device_precision(cfg: Dict, device_type: str, precision: Unio
     dev_prec_override = {"dtype": get_model_input_dtype(precision), "device": device_type}
     if isinstance(cfg.tl_cfg, ITLensCustomConfig):  # initialized TL custom model config
         cfg.tl_cfg.cfg.__dict__.update(dev_prec_override)
-    elif isinstance(cfg.tl_cfg, ITLensFromPretrainedConfig):
-        # TL from pretrained config, we set directly in addition to pretrained above to verify sync behavior
+    elif isinstance(cfg.tl_cfg, (ITLensFromPretrainedConfig, ITLensBridgeConfig)):
+        # TL from pretrained or bridge config, we set directly in addition to pretrained above to verify sync behavior
         cfg.tl_cfg.__dict__.update(dev_prec_override)
     else:  # likely uninitialized TL custom model config, may want to remove this branch/check
         assert cfg.tl_cfg.get("cfg", None)

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -70,6 +70,7 @@ def apply_it_test_cfg(base_it_cfg: ITConfig, test_cfg: BaseCfg, core_log_dir: Op
         "sae_analysis_targets",
         "analysis_cfgs",
         "sae_cfgs",
+        "logging_level",
     ]
     test_it_cfg = deepcopy(base_it_cfg)
     for attr in test_cfg_override_attrs:
@@ -154,6 +155,9 @@ def gen_session_cfg(
     test_cfg, test_alias, expected_results, tmp_path, prewrapped_modules, state_log_mode: bool = False
 ) -> ITSessionConfig:
     base_itdm_cfg, base_it_cfg, dm_cls, m_cls = MODULE_EXAMPLE_REGISTRY.get(test_cfg)
+    # Override with test_cfg classes if provided, ITSessionConfig.__post_init__ handles str-to-class conversion
+    m_cls = test_cfg.module_cls if test_cfg.module_cls is not None else m_cls
+    dm_cls = test_cfg.datamodule_cls if test_cfg.datamodule_cls is not None else dm_cls
     itdm_cfg = apply_itdm_test_cfg(base_itdm_cfg=base_itdm_cfg, test_cfg=test_cfg)
     it_cfg = apply_it_test_cfg(base_it_cfg=base_it_cfg, test_cfg=test_cfg, core_log_dir=tmp_path)
     core_cfg = {"datamodule_cls": dm_cls, "module_cls": m_cls, "datamodule_cfg": itdm_cfg, "module_cfg": it_cfg}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,8 @@ from tests.core.cfg_aliases import (
     TLDebugCfg,
     LightningLlama3DebugCfg,
     LightningGemma2DebugCfg,
+    LightningTLBridgeLlama3,
+    LightningTLBridgeGemma2,
     CoreMemProfCfg,
     CoreGPT2PEFTCfg,
     CoreGPT2PEFTSeqCfg,
@@ -58,6 +60,7 @@ from tests.core.cfg_aliases import (
     LightningGPT2,
     LightningTLGPT2,
     LightningTLBridgeGPT2,
+    LightningTLBridgeGPT2Processed,
     CoreSLGPT2,
     CoreSLGPT2Analysis,
     CoreSLCust,
@@ -161,7 +164,16 @@ FIXTURE_CFGS = {
     "l_gpt2": FixtureCfg(test_cfg=LightningGPT2, scope="function", variants={"it_session": [FixtPhase.setup]}),
     "l_tl_ht_gpt2": FixtureCfg(test_cfg=LightningTLGPT2, scope="function", variants={"it_session": [FixtPhase.setup]}),
     "l_tl_bridge_gpt2": FixtureCfg(
-        test_cfg=LightningTLBridgeGPT2, scope="function", variants={"it_session": [FixtPhase.setup]}
+        test_cfg=LightningTLBridgeGPT2, scope="module", variants={"it_session": [FixtPhase.setup]}
+    ),
+    "l_tl_bridge_gpt2_processed": FixtureCfg(
+        test_cfg=LightningTLBridgeGPT2Processed, scope="module", variants={"it_session": [FixtPhase.setup]}
+    ),
+    "l_tl_bridge_llama3": FixtureCfg(
+        test_cfg=LightningTLBridgeLlama3, scope="function", variants={"it_session": [FixtPhase.setup]}
+    ),
+    "l_tl_bridge_gemma2": FixtureCfg(
+        test_cfg=LightningTLBridgeGemma2, scope="function", variants={"it_session": [FixtPhase.setup]}
     ),
     "l_sl_gpt2": FixtureCfg(test_cfg=LightningSLGPT2, variants={"it_session": [FixtPhase.initonly]}),
     "l_llama3_debug": FixtureCfg(test_cfg=LightningLlama3DebugCfg, variants={"it_session": [FixtPhase.setup]}),
@@ -194,6 +206,11 @@ FIXTURE_CFGS = {
         variants={"analysis_session": [FixtRunPhase(FixtPhase.initonly, RunPhase.runanalysis)]},
     ),
     "tl_gpt2_debug": FixtureCfg(test_cfg=TLDebugCfg, variants={"it_session": [FixtPhase.setup]}),
+    # FT Schedule fixtures (function-scoped for per-test generation)
+    "l_gpt2_sched": FixtureCfg(scope="function", variants={"ft_schedule": [FixtPhase.setup]}),
+    "l_tl_ht_gpt2_sched": FixtureCfg(scope="function", variants={"ft_schedule": [FixtPhase.setup]}),
+    "l_tl_bridge_gpt2_sched": FixtureCfg(scope="function", variants={"ft_schedule": [FixtPhase.setup]}),
+    "l_tl_bridge_gpt2_tl_names_sched": FixtureCfg(scope="function", variants={"ft_schedule": [FixtPhase.setup]}),
 }
 
 
@@ -386,6 +403,92 @@ def it_session_cfg_fixture_factory(config_key):
     return get_it_session_cfg
 
 
+def ft_schedule_fixture_factory(config_key, phase):
+    """Factory for creating FT schedule fixtures on-demand.
+
+    Generates a fine-tuning schedule for the specified config_key. This replaces the monolithic
+    gpt2_ft_schedules fixture that generated all schedules upfront.
+
+    Args:
+        config_key: Schedule configuration key (e.g., 'l_gpt2_sched', 'l_tl_bridge_gpt2_sched')
+        phase: FixtPhase (currently only FixtPhase.setup is supported)
+
+    Returns:
+        A pytest fixture that generates the requested schedule
+    """
+
+    @pytest.fixture(scope=FIXTURE_CFGS[config_key].scope)
+    def get_ft_schedule(tmpdir_factory, request):
+        """Generate a fine-tuning schedule for this specific configuration."""
+        from tests.parity_acceptance.cfg_aliases import tl_bridge_custom_adapter_map
+
+        # Map config_key to model_key and schedule transforms
+        # Defined here to have access to transform functions that are defined later in conftest.py
+        SCHEDULE_CONFIG_MAP = {
+            "l_gpt2_sched": {
+                "model_key": "l_gpt2",
+                "session_fixture": "get_it_session__l_gpt2__setup",
+                "transforms": {"basic_explicit": l_imp_to_exp, "multiphase_explicit": l_multiphase_explicit},
+                "fts_kwargs": {},
+            },
+            "l_tl_ht_gpt2_sched": {
+                "model_key": "l_tl_ht_gpt2",
+                "session_fixture": "get_it_session__l_tl_ht_gpt2__setup",
+                "transforms": {"multiphase_explicit": tl_ht_multiphase_explicit},
+                "fts_kwargs": {},
+            },
+            "l_tl_bridge_gpt2_sched": {
+                "model_key": "l_tl_bridge_gpt2",
+                "session_fixture": "get_it_session__l_tl_bridge_gpt2__setup",
+                "transforms": {"multiphase_explicit": tl_bridge_multiphase_explicit},
+                "fts_kwargs": {
+                    "custom_strategy_adapters": tl_bridge_custom_adapter_map,
+                },
+            },
+            "l_tl_bridge_gpt2_tl_names_sched": {
+                "model_key": "l_tl_bridge_gpt2",
+                "session_fixture": "get_it_session__l_tl_bridge_gpt2__setup",
+                "transforms": {"multiphase_explicit_tl_names": tl_bridge_multiphase_explicit_tl_names},
+                "fts_kwargs": {
+                    "custom_strategy_adapters": tl_bridge_custom_adapter_map,
+                    "strategy_adapter_cfg": {"use_tl_names": True},
+                },
+            },
+        }
+
+        sched_cfg = SCHEDULE_CONFIG_MAP[config_key]
+
+        seed_everything(42)
+        tmpdir = tmpdir_factory.mktemp(f"test_fts_schedules_{config_key}")
+        rank = getattr(rank_zero_only, "rank", 0)
+
+        # Get the session fixture for this model
+        session_fixture = request.getfixturevalue(sched_cfg["session_fixture"])
+        model = deepcopy(session_fixture.it_session.module)
+
+        # Create FinetuningScheduler with model-specific kwargs
+        fts_kwargs = sched_cfg["fts_kwargs"]
+        callbacks = [FinetuningScheduler(gen_ft_sched_only=True, **fts_kwargs)]
+        trainer = Trainer(default_root_dir=tmpdir, callbacks=callbacks, devices=1)
+        schedule_filename = f"{model.__class__.__name__}_ft_schedule.yaml"
+        unmod_schedule_file = tmpdir / "lightning_logs" / "version_0" / schedule_filename
+
+        # Generate schedule on rank 0
+        if rank == 0:
+            with pytest.raises(SystemExit):
+                trainer.fit(model)
+
+        # Load implicit schedule and apply transforms
+        schedules = {}
+        schedules["implicit"] = get_fts(trainer).load_yaml_schedule(unmod_schedule_file)
+        for transform_key, transform_fn in sched_cfg["transforms"].items():
+            schedules[transform_key] = transform_fn(deepcopy(schedules["implicit"]))
+
+        return schedules
+
+    return get_ft_schedule
+
+
 def gen_fixture(fixt_type, fixt_key, phase):
     if isinstance(phase, FixtRunPhase):
         fixt_phase, run_phase = phase.fixt_phase, phase.run_phase
@@ -410,6 +513,9 @@ def gen_fixture(fixt_type, fixt_key, phase):
     elif fixt_type == "analysis_session":
         name = f"get_analysis_session__{fixt_key}__{phase_str}"
         factory = analysis_session_fixture_factory
+    elif fixt_type == "ft_schedule":
+        name = f"get_ft_schedule__{fixt_key}__{phase_str}"
+        factory = ft_schedule_fixture_factory
     else:
         raise NotImplementedError
     globals()[name] = factory(*args)
@@ -561,9 +667,7 @@ def tl_ht_imp_to_exp(sched_dict: Dict) -> Dict:
     sched_dict[0]["max_transition_epoch"] = 2
     phase_1_pats = [
         r"model.blocks.([0-8](?!\d)).*",
-        r"model.(pos_embed|embed).*",
-        "model.unembed.W_U",  # HookedTransformer parameter names
-        "model.unembed.b_U",  # HookedTransformer parameter names
+        r"model.(pos_embed|embed|unembed).*",
     ]
     sched_dict[1]["params"] = phase_1_pats
     sched_dict[1]["lr"] = 1e-06
@@ -583,9 +687,7 @@ def tl_ht_multiphase_explicit(sched_dict: Dict) -> Dict:
     sched_dict[2] = {
         "params": [
             r"model.blocks.([0-6](?!\d)).*",
-            r"model.(pos_embed|embed).*",
-            "model.unembed.W_U",
-            "model.unembed.b_U",
+            r"model.(pos_embed|embed|unembed).*",
         ],
         "lr": 1e-06,
     }
@@ -598,11 +700,7 @@ def tl_bridge_imp_to_exp(sched_dict: Dict) -> Dict:
     sched_dict[0]["max_transition_epoch"] = 2
     phase_1_pats = [
         r"model.blocks.([0-8](?!\d)).*",
-        r"model.(pos_embed|embed).*",
-        # TransformerBridge uses _original_component wrapper for parameter names
-        "model.unembed._original_component.weight",
-        # Note: GPT2 unembed typically doesn't have bias, but including pattern for completeness
-        # "model.unembed._original_component.bias",  # Uncomment if TransformerBridge model has unembed bias
+        r"model.(pos_embed|embed|unembed).*",
     ]
     sched_dict[1]["params"] = phase_1_pats
     sched_dict[1]["lr"] = 1e-06
@@ -622,57 +720,46 @@ def tl_bridge_multiphase_explicit(sched_dict: Dict) -> Dict:
     sched_dict[2] = {
         "params": [
             r"model.blocks.([0-6](?!\d)).*",
-            r"model.(pos_embed|embed).*",
-            "model.unembed._original_component.weight",
-            # "model.unembed._original_component.bias",  # Uncomment if TransformerBridge model has unembed bias
+            r"model.(pos_embed|embed|unembed).*",
         ],
         "lr": 1e-06,
     }
     return sched_dict
 
 
-@pytest.fixture(scope="function")
-def gpt2_ft_schedules(
-    tmpdir_factory,
-    # fts_patch_env,
-    get_it_session__l_gpt2__setup,
-    get_it_session__l_tl_ht_gpt2__setup,
-    get_it_session__l_tl_bridge_gpt2__setup,
-) -> Tuple[Path, Dict]:
-    """Generates a default fine-tuning schedule for 'implicit' testing, a modified one for 'explicit' mode and an
-    epoch-driven transitions only one for epoch_transitions_only testing."""
-    SCHED_TRANSFORMS = defaultdict(dict)
-    SCHED_TRANSFORMS["l_gpt2"]["basic_explicit"] = l_imp_to_exp
-    # SCHED_TRANSFORMS["l_gpt2"]["multiphase_explicit"] = l_multiphase_explicit  # not currently used
-    # SCHED_TRANSFORMS["l_tl_ht_gpt2"]["basic_explicit"] = tl_imp_to_exp  # not currently used
-    SCHED_TRANSFORMS["l_tl_ht_gpt2"]["multiphase_explicit"] = tl_ht_multiphase_explicit
-    # SCHED_TRANSFORMS["l_tl_bridge_gpt2"]["basic_explicit"] = tl_bridge_imp_to_exp  # not currently used
-    SCHED_TRANSFORMS["l_tl_bridge_gpt2"]["multiphase_explicit"] = tl_bridge_multiphase_explicit
-    seed_everything(42)
-    callbacks = [FinetuningScheduler(gen_ft_sched_only=True)]
-    # for simplicity, initially only running FTS non-distributed tests
-    tmpdir = tmpdir_factory.mktemp("test_fts_schedules")
-    rank = getattr(rank_zero_only, "rank", 0)
-    models = {
-        "l_gpt2": deepcopy(get_it_session__l_gpt2__setup.it_session.module),
-        "l_tl_ht_gpt2": deepcopy(get_it_session__l_tl_ht_gpt2__setup.it_session.module),
-        "l_tl_bridge_gpt2": deepcopy(get_it_session__l_tl_bridge_gpt2__setup.it_session.module),
+def tl_bridge_multiphase_explicit_tl_names(sched_dict: Dict) -> Dict:
+    """Multi-level TL-style schedule for l_tl_bridge_gpt2: uses clean TL parameter names.
+
+    This variant uses TL-style naming (e.g., blocks.9.attn.W_Q) instead of canonical names
+    (e.g., model.blocks.9._original_component.attn.q._original_component.weight).
+
+    Unlike canonical schedules, TL-style schedules should ONLY contain TL-style parameter names.
+    We create a fresh schedule dict with only the 3 phases we need.
+    """
+    # Create a fresh schedule with only TL-style phases (removes all canonical-named phases)
+    tl_sched = {}
+
+    # Phase 0: layers 9-11
+    tl_sched[0] = {
+        "params": [r"blocks.(9|1[0-1]).*"],
+        "max_transition_epoch": 2,
     }
-    test_schedules = defaultdict(dict)
-    for i, (model_key, model) in enumerate(models.items()):
-        trainer = Trainer(default_root_dir=tmpdir, callbacks=callbacks, devices=1)
-        unmod_schedule_file = (
-            tmpdir / "lightning_logs" / f"version_{i}" / f"{model.__class__.__name__}_ft_schedule.yaml"
-        )
-        # N.B. Though we run this fixture for each rank to avoid adding special logic to each distributed client test,
-        # we only generate a schedule on rank 0, linking to it on the other ranks.
-        if rank == 0:
-            with pytest.raises(SystemExit):
-                trainer.fit(model)
-        test_schedules[model_key]["implicit"] = get_fts(trainer).load_yaml_schedule(unmod_schedule_file)
-        for transform_key, transform_fn in SCHED_TRANSFORMS[model_key].items():
-            test_schedules[model_key][transform_key] = transform_fn(deepcopy(test_schedules[model_key]["implicit"]))
-    return test_schedules
+
+    # Phase 1: layers 7-8 only
+    tl_sched[1] = {
+        "params": [r"blocks.([7-8]).*"],
+        "max_transition_epoch": 3,
+    }
+
+    # Phase 2: layers 0-6 and embeddings
+    tl_sched[2] = {
+        "params": [
+            r"blocks.([0-6](?!\d)).*",  # Layers 0-6
+            r"(pos_embed|embed|unembed).*",  # Embeddings (no 'model.' prefix in TL-style)
+        ],
+        "lr": 1e-06,
+    }
+    return tl_sched
 
 
 #################################

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ FIXTURE_CFGS = {
     "core_gpt2_peft_seq": FixtureCfg(test_cfg=CoreGPT2PEFTSeqCfg, variants={"it_session": [FixtPhase.initonly]}),
     "core_cust_memprof": FixtureCfg(test_cfg=CoreMemProfCfg, variants={"it_session": [FixtPhase.initonly]}),
     "l_gpt2": FixtureCfg(test_cfg=LightningGPT2, scope="function", variants={"it_session": [FixtPhase.setup]}),
-    "l_tl_gpt2": FixtureCfg(test_cfg=LightningTLGPT2, scope="function", variants={"it_session": [FixtPhase.setup]}),
+    "l_tl_ht_gpt2": FixtureCfg(test_cfg=LightningTLGPT2, scope="function", variants={"it_session": [FixtPhase.setup]}),
     "l_tl_bridge_gpt2": FixtureCfg(
         test_cfg=LightningTLBridgeGPT2, scope="function", variants={"it_session": [FixtPhase.setup]}
     ),
@@ -522,17 +522,6 @@ def cli_test_configs(cli_test_file_env):
 #################################
 # Schedule Fixtures
 #################################
-
-
-@pytest.fixture(scope="function")
-def fts_patch_env():
-    os.environ["FTS_GEN_SCHEDULE_ALLOW_DUPLICATE"] = "True"
-    yield
-    for env_key in ("FTS_GEN_SCHEDULE_ALLOW_DUPLICATE",):
-        if env_key in os.environ:
-            del os.environ[env_key]
-
-
 def l_imp_to_exp(sched_dict: Dict) -> Dict:
     sched_dict[0]["params"] = [r"model.transformer.h.(9|1[0-1]).(mlp|attn|ln_(1|2)).(c_proj|c_fc|c_attn|weight|bias).*"]
     sched_dict[0]["max_transition_epoch"] = 2
@@ -547,7 +536,27 @@ def l_imp_to_exp(sched_dict: Dict) -> Dict:
     return sched_dict
 
 
-def tl_imp_to_exp(sched_dict: Dict) -> Dict:
+def l_multiphase_explicit(sched_dict: Dict) -> Dict:
+    """Multi-level explicit schedule for l_gpt2: splits basic_explicit into 3 phases."""
+    # Start with basic_explicit transformation
+    sched_dict = l_imp_to_exp(sched_dict)
+    # Phase 0: layers 9-11 (unchanged from basic_explicit)
+    # Phase 1: layers 7-8 only (split from original phase 1)
+    sched_dict[1]["params"] = [r"model.transformer.h.([7-8]).(mlp|attn|ln_(1|2)).(c_proj|c_fc|c_attn|weight|bias).*"]
+    sched_dict[1]["max_transition_epoch"] = 3
+    # Phase 2: layers 0-6 and embeddings
+    sched_dict[2] = {
+        "params": [
+            r"model.transformer.h.([0-6](?!\d)).(mlp|attn|ln_(1|2)).(c_proj|c_fc|c_attn|weight|bias).*",
+            r"model.transformer.(wpe|wte).weight",
+            r"model.transformer.ln_f.*",
+        ],
+        "lr": 1e-06,
+    }
+    return sched_dict
+
+
+def tl_ht_imp_to_exp(sched_dict: Dict) -> Dict:
     sched_dict[0]["params"] = [r"model.blocks.(9|1[0-1]).*"]
     sched_dict[0]["max_transition_epoch"] = 2
     phase_1_pats = [
@@ -559,6 +568,27 @@ def tl_imp_to_exp(sched_dict: Dict) -> Dict:
     sched_dict[1]["params"] = phase_1_pats
     sched_dict[1]["lr"] = 1e-06
     sched_dict = {phase: phase_def for phase, phase_def in sched_dict.items() if phase in range(2)}
+    return sched_dict
+
+
+def tl_ht_multiphase_explicit(sched_dict: Dict) -> Dict:
+    """Multi-level explicit schedule for l_tl_ht_gpt2: splits basic_explicit into 3 phases."""
+    # Start with basic_explicit transformation
+    sched_dict = tl_ht_imp_to_exp(sched_dict)
+    # Phase 0: layers 9-11 (unchanged from basic_explicit)
+    # Phase 1: layers 7-8 only (split from original phase 1)
+    sched_dict[1]["params"] = [r"model.blocks.([7-8]).*"]
+    sched_dict[1]["max_transition_epoch"] = 3
+    # Phase 2: layers 0-6 and embeddings
+    sched_dict[2] = {
+        "params": [
+            r"model.blocks.([0-6](?!\d)).*",
+            r"model.(pos_embed|embed).*",
+            "model.unembed.W_U",
+            "model.unembed.b_U",
+        ],
+        "lr": 1e-06,
+    }
     return sched_dict
 
 
@@ -580,20 +610,44 @@ def tl_bridge_imp_to_exp(sched_dict: Dict) -> Dict:
     return sched_dict
 
 
+def tl_bridge_multiphase_explicit(sched_dict: Dict) -> Dict:
+    """Multi-level explicit schedule for l_tl_bridge_gpt2: splits basic_explicit into 3 phases."""
+    # Start with basic_explicit transformation
+    sched_dict = tl_bridge_imp_to_exp(sched_dict)
+    # Phase 0: layers 9-11 (unchanged from basic_explicit)
+    # Phase 1: layers 7-8 only (split from original phase 1)
+    sched_dict[1]["params"] = [r"model.blocks.([7-8]).*"]
+    sched_dict[1]["max_transition_epoch"] = 3
+    # Phase 2: layers 0-6 and embeddings
+    sched_dict[2] = {
+        "params": [
+            r"model.blocks.([0-6](?!\d)).*",
+            r"model.(pos_embed|embed).*",
+            "model.unembed._original_component.weight",
+            # "model.unembed._original_component.bias",  # Uncomment if TransformerBridge model has unembed bias
+        ],
+        "lr": 1e-06,
+    }
+    return sched_dict
+
+
 @pytest.fixture(scope="function")
 def gpt2_ft_schedules(
     tmpdir_factory,
-    fts_patch_env,
+    # fts_patch_env,
     get_it_session__l_gpt2__setup,
-    get_it_session__l_tl_gpt2__setup,
+    get_it_session__l_tl_ht_gpt2__setup,
     get_it_session__l_tl_bridge_gpt2__setup,
 ) -> Tuple[Path, Dict]:
     """Generates a default fine-tuning schedule for 'implicit' testing, a modified one for 'explicit' mode and an
     epoch-driven transitions only one for epoch_transitions_only testing."""
     SCHED_TRANSFORMS = defaultdict(dict)
     SCHED_TRANSFORMS["l_gpt2"]["basic_explicit"] = l_imp_to_exp
-    SCHED_TRANSFORMS["l_tl_gpt2"]["basic_explicit"] = tl_imp_to_exp
-    SCHED_TRANSFORMS["l_tl_bridge_gpt2"]["basic_explicit"] = tl_bridge_imp_to_exp
+    # SCHED_TRANSFORMS["l_gpt2"]["multiphase_explicit"] = l_multiphase_explicit  # not currently used
+    # SCHED_TRANSFORMS["l_tl_ht_gpt2"]["basic_explicit"] = tl_imp_to_exp  # not currently used
+    SCHED_TRANSFORMS["l_tl_ht_gpt2"]["multiphase_explicit"] = tl_ht_multiphase_explicit
+    # SCHED_TRANSFORMS["l_tl_bridge_gpt2"]["basic_explicit"] = tl_bridge_imp_to_exp  # not currently used
+    SCHED_TRANSFORMS["l_tl_bridge_gpt2"]["multiphase_explicit"] = tl_bridge_multiphase_explicit
     seed_everything(42)
     callbacks = [FinetuningScheduler(gen_ft_sched_only=True)]
     # for simplicity, initially only running FTS non-distributed tests
@@ -601,7 +655,7 @@ def gpt2_ft_schedules(
     rank = getattr(rank_zero_only, "rank", 0)
     models = {
         "l_gpt2": deepcopy(get_it_session__l_gpt2__setup.it_session.module),
-        "l_tl_gpt2": deepcopy(get_it_session__l_tl_gpt2__setup.it_session.module),
+        "l_tl_ht_gpt2": deepcopy(get_it_session__l_tl_ht_gpt2__setup.it_session.module),
         "l_tl_bridge_gpt2": deepcopy(get_it_session__l_tl_bridge_gpt2__setup.it_session.module),
     }
     test_schedules = defaultdict(dict)

--- a/tests/core/cfg_aliases.py
+++ b/tests/core/cfg_aliases.py
@@ -15,6 +15,7 @@ from interpretune.config import (
     ITLensCustomConfig,
     TLensGenerationConfig,
     AutoCompConfig,
+    ITLensBridgeConfig,
     ITLensFromPretrainedNoProcessingConfig,
     SAELensFromPretrainedConfig,
     AnalysisCfg,
@@ -175,6 +176,53 @@ class LightningGemma2DebugCfg(BaseCfg):
 
 
 @dataclass(kw_only=True)
+class LightningTLBridgeLlama3(BaseCfg):
+    """Llama3 with TransformerBridge for parameter mapping validation tests.
+
+    Uses meta-llama/Llama-3.2-3B-Instruct (registry default for model_src_key=llama3).
+    Exercises:
+    - GQA (grouped-query attention) with n_key_value_heads != n_heads
+    - SwiGLU MLP with gate projection (W_gate)
+    - RMSNorm instead of LayerNorm
+    """
+
+    model_src_key: str | None = "llama3"
+    device_type: str | None = "cuda"
+    precision: str | int | None = "bf16-true"
+    adapter_ctx: Sequence[Adapter | str] = (Adapter.lightning, Adapter.transformer_lens)
+    tl_cfg: ITLensBridgeConfig = field(
+        default_factory=lambda: ITLensBridgeConfig(
+            model_name="meta-llama/Llama-3.2-3B-Instruct",
+            default_padding_side="left",
+        )
+    )
+
+
+@dataclass(kw_only=True)
+class LightningTLBridgeGemma2(BaseCfg):
+    """Gemma2 with TransformerBridge for parameter mapping validation tests.
+
+    Uses google/gemma-2-2b for reasonable test size while exercising:
+    - Sliding window attention with interleaved global attention
+    - GeGLU activation with gate projection
+    - RMSNorm instead of LayerNorm
+    """
+
+    model_src_key: str | None = "gemma2"
+    device_type: str | None = "cuda"
+    precision: str | int | None = "bf16-true"
+    adapter_ctx: Sequence[Adapter | str] = (Adapter.lightning, Adapter.transformer_lens)
+    tl_cfg: ITLensBridgeConfig = field(
+        default_factory=lambda: ITLensBridgeConfig(
+            model_name="google/gemma-2-2b",
+            default_padding_side="left",
+        )
+    )
+    datamodule_cls: str | None = "tests.modules.FingerprintTestITDataModule"
+    module_cls: str | None = "tests.modules.TestITModule"
+
+
+@dataclass(kw_only=True)
 class LightningGPT2(BaseCfg):
     model_src_key: str | None = "gpt2"
     adapter_ctx: Sequence[Adapter | str] = (Adapter.lightning,)
@@ -196,10 +244,30 @@ class LightningTLGPT2(BaseCfg):
 class LightningTLBridgeGPT2(BaseCfg):
     model_src_key: str | None = "gpt2"
     adapter_ctx: Sequence[Adapter | str] = (Adapter.lightning, Adapter.transformer_lens)
-    # logging_level: str | int = "DEBUG"
-    tl_cfg: ITLensFromPretrainedNoProcessingConfig = field(
-        default_factory=lambda: ITLensFromPretrainedNoProcessingConfig(
-            model_name="gpt2-small", default_padding_side="left", use_bridge=True
+    logging_level: str | int = "DEBUG"
+    tl_cfg: ITLensBridgeConfig = field(
+        default_factory=lambda: ITLensBridgeConfig(
+            model_name="gpt2-small",
+            default_padding_side="left",
+        )
+    )
+
+
+@dataclass(kw_only=True)
+class LightningTLBridgeGPT2Processed(BaseCfg):
+    """GPT-2 with TransformerBridge using default weight processing (fold_ln, fold_value_biases, etc.).
+
+    This config uses ITLensBridgeConfig with enable_compatibility_mode=True to apply fold_ln=True,
+    fold_value_biases=True, etc. Used to test bidirectional mapping behavior when LayerNorms are folded etc.
+    """
+
+    model_src_key: str | None = "gpt2"
+    adapter_ctx: Sequence[Adapter | str] = (Adapter.lightning, Adapter.transformer_lens)
+    tl_cfg: ITLensBridgeConfig = field(
+        default_factory=lambda: ITLensBridgeConfig(
+            model_name="gpt2-small",
+            default_padding_side="left",
+            enable_compatibility_mode=True,
         )
     )
 

--- a/tests/core/cfg_aliases.py
+++ b/tests/core/cfg_aliases.py
@@ -196,6 +196,7 @@ class LightningTLGPT2(BaseCfg):
 class LightningTLBridgeGPT2(BaseCfg):
     model_src_key: str | None = "gpt2"
     adapter_ctx: Sequence[Adapter | str] = (Adapter.lightning, Adapter.transformer_lens)
+    # logging_level: str | int = "DEBUG"
     tl_cfg: ITLensFromPretrainedNoProcessingConfig = field(
         default_factory=lambda: ITLensFromPretrainedNoProcessingConfig(
             model_name="gpt2-small", default_padding_side="left", use_bridge=True

--- a/tests/core/test_transformer_lens.py
+++ b/tests/core/test_transformer_lens.py
@@ -1,10 +1,13 @@
 from copy import deepcopy
+import inspect
 
 import pytest
 from torch import device
+from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
 
 from interpretune.config import ITLensFromPretrainedConfig, ITLensConfig, ITLensCustomConfig
 from interpretune.utils import MisconfigurationException
+from interpretune.adapters.transformer_lens import TransformerBridgeStrategyAdapter
 from tests.warns import unexpected_warns, TL_CTX_WARNS
 from tests.utils import ablate_cls_attrs
 from tests.base_defaults import default_test_task
@@ -199,3 +202,17 @@ class TestClassTransformerLens:
         with pytest.warns(UserWarning, match="ITLensCustomConfig does not support TransformerBridge"):
             it_cfg_custom_override = ITLensConfig(**test_tl_cfg_custom_override)
         assert it_cfg_custom_override.tl_cfg.use_bridge is False
+
+
+def test_transformerbridge_adapter_basic_properties():
+    """Sanity check for TransformerBridgeStrategyAdapter plugin.
+
+    This ensures the adapter is well-formed and provides the hooks required by FTS restore logic.
+    """
+    assert issubclass(TransformerBridgeStrategyAdapter, StrategyAdapter)
+    methods = inspect.getmembers(TransformerBridgeStrategyAdapter, predicate=inspect.isfunction)
+    method_names = {n for n, _ in methods}
+    # Should implement the adapter's before_restore_model hook (new preferred name) and backward compat alias
+    assert "before_restore_model" in method_names
+    assert "fts_optim_transform" in method_names
+    assert "logical_param_translation" in method_names

--- a/tests/core/test_transformer_lens.py
+++ b/tests/core/test_transformer_lens.py
@@ -454,11 +454,6 @@ class TestBasicTransformerBridgeAdapter:
         assert "blocks" in tl_name or "embed" in tl_name or "unembed" in tl_name
         assert "_original_component" in expected_canonical_pattern or expected_canonical_pattern == "model.unembed.W_U"
 
-    def test_inspect_state(self):
-        """Test that inspect_state utility is available as static method."""
-        assert hasattr(TransformerBridgeStrategyAdapter, "inspect_state")
-        assert callable(TransformerBridgeStrategyAdapter.inspect_state)
-
     def test_gen_ft_schedule_disabled(self):
         """Test gen_ft_schedule delegates to parent when use_tl_names=False."""
         adapter = TransformerBridgeStrategyAdapter(use_tl_names=False)
@@ -472,8 +467,6 @@ class TestBasicTransformerBridgeAdapter:
 # =============================================================================
 # Parameter Mapping Validation Tests
 # =============================================================================
-
-
 class TestArchitectureParameterMapping:
     """Parameterized architecture parameter mapping tests.
 

--- a/tests/core/test_transformer_lens.py
+++ b/tests/core/test_transformer_lens.py
@@ -708,7 +708,7 @@ class TestArchitectureParameterMapping:
         ],
     )
     def test_bidirectional_mapping(self, request, session_fixture: str, arch_expectations: ArchitectureExpectations):
-        """Validate bidirectional TL ↔ canonical parameter mapping using component tracing.
+        """Validate bidirectional TL <-> canonical parameter mapping using component tracing.
 
         First validates TL parameter structure as a precondition, then tests the
         TransformerBridgeStrategyAdapter's _build_param_mapping() method which uses
@@ -752,7 +752,7 @@ class TestArchitectureParameterMapping:
         assert tl_to_canonical is not None, "TL to canonical mapping not built"
         assert canonical_to_tl is not None, "Canonical to TL mapping not built"
 
-        # ===== TL → Canonical Mapping Validation =====
+        # ===== TL -> Canonical Mapping Validation =====
         unmapped_tl = []
         mapped_tl_count = 0
         for tl_name in tl_params.keys():
@@ -768,7 +768,7 @@ class TestArchitectureParameterMapping:
                 unmapped_tl.append(tl_name)
 
         print(
-            f"[{arch_expectations.model_name}] TL→Canonical: {mapped_tl_count}/{len(tl_params)} mapped, "
+            f"[{arch_expectations.model_name}] TL->Canonical: {mapped_tl_count}/{len(tl_params)} mapped, "
             f"{len(unmapped_tl)} unmapped"
         )
 
@@ -783,12 +783,12 @@ class TestArchitectureParameterMapping:
             f"Unmapped: {unmapped_tl[:10]}"
         )
 
-        # ===== Canonical → TL Mapping Validation =====
+        # ===== Canonical -> TL Mapping Validation =====
         mapped_canonical_count = len(canonical_to_tl)
         unmapped_canonical = [k for k in canonical_params.keys() if k not in canonical_to_tl]
 
         print(
-            f"[{arch_expectations.model_name}] Canonical→TL: {mapped_canonical_count}/{len(canonical_params)} mapped, "
+            f"[{arch_expectations.model_name}] Canonical->TL: {mapped_canonical_count}/{len(canonical_params)} mapped, "
             f"{len(unmapped_canonical)} unmapped"
         )
 
@@ -812,7 +812,7 @@ class TestArchitectureParameterMapping:
             # Verify bidirectional consistency
             assert canonical_name in tl_to_canonical.get(tl_name, []), (
                 f"[{arch_expectations.model_name}] Bidirectional inconsistency: "
-                f"canonical '{canonical_name}' → TL '{tl_name}' but TL doesn't map back"
+                f"canonical '{canonical_name}' -> TL '{tl_name}' but TL doesn't map back"
             )
 
 

--- a/tests/core/test_transformer_lens.py
+++ b/tests/core/test_transformer_lens.py
@@ -1,7 +1,11 @@
 from copy import deepcopy
+from dataclasses import dataclass, field
 import inspect
+import re
+from typing import Dict, List, Optional, Set, Tuple
 
 import pytest
+import torch
 from torch import device
 from finetuning_scheduler.strategy_adapters.base import StrategyAdapter
 
@@ -11,6 +15,196 @@ from interpretune.adapters.transformer_lens import TransformerBridgeStrategyAdap
 from tests.warns import unexpected_warns, TL_CTX_WARNS
 from tests.utils import ablate_cls_attrs
 from tests.base_defaults import default_test_task
+from tests.runif import RunIf
+
+
+# =============================================================================
+# Architecture-Specific Parameter Mapping Expectations
+# =============================================================================
+
+
+@dataclass
+class ArchitectureExpectations:
+    """Expected parameter structure for a specific model architecture.
+
+    Attributes:
+        model_name: Human-readable model name for test identification
+        n_layers: Number of transformer layers
+        n_heads: Number of attention heads
+        n_kv_heads: Number of key/value heads (for GQA)
+        d_model: Model dimension
+        has_pos_embed: Whether model has learnable position embeddings (False for RoPE)
+        has_gate_proj: Whether MLP has gate projection (SwiGLU/GeGLU)
+        has_biases: Whether attention/MLP have biases
+        expected_tl_attn_params: Per-layer attention param suffixes to expect
+        expected_tl_mlp_params: Per-layer MLP param suffixes to expect
+        expected_tl_embed_params: Embedding params to expect
+        canonical_attn_pattern: Regex pattern for canonical attention params (for mapping validation)
+        canonical_mlp_pattern: Regex pattern for canonical MLP params (for mapping validation)
+        canonical_embed_pattern: Regex pattern for canonical embedding params (for mapping validation)
+        expected_mapped_tl_count: Expected number of TL params with canonical mappings
+        expected_unmapped_tl_count: Expected number of unmapped TL params (synthetic biases)
+        expected_mapped_canonical_count: Expected number of canonical params with TL mappings
+        expected_unmapped_canonical_count: Expected number of unmapped canonical params
+                                          (LayerNorms, pre-split QKV, etc.)
+    """
+
+    model_name: str
+    n_layers: int
+    n_heads: int
+    n_kv_heads: int
+    d_model: int
+    has_pos_embed: bool = False
+    has_gate_proj: bool = True
+    has_biases: bool = False
+
+    # TL-style parameter suffixes expected per layer
+    expected_tl_attn_params: List[str] = field(default_factory=lambda: ["attn.W_Q", "attn.W_K", "attn.W_V", "attn.W_O"])
+    expected_tl_mlp_params: List[str] = field(default_factory=lambda: ["mlp.W_in", "mlp.W_out"])
+    expected_tl_embed_params: List[str] = field(default_factory=lambda: ["embed.W_E", "unembed.W_U"])
+
+    # Canonical naming patterns (regex) - architecture specific
+    # These are used to validate bidirectional mapping
+    canonical_attn_pattern: Optional[str] = None
+    canonical_mlp_pattern: Optional[str] = None
+    canonical_embed_pattern: Optional[str] = None
+
+    # Expected mapping counts for bidirectional validation
+    expected_mapped_tl_count: Optional[int] = None
+    expected_unmapped_tl_count: int = 0  # All TL params should map
+    expected_mapped_canonical_count: Optional[int] = None
+    expected_unmapped_canonical_count: Optional[int] = None
+
+
+# Pre-defined architecture expectations
+# NOTE: The actual model loaded depends on registry resolution for model_src_key.
+# model_src_key="llama3" resolves to meta-llama/Llama-3.2-3B-Instruct (28 layers, not Llama-3.2-1B)
+LLAMA3_EXPECTATIONS = ArchitectureExpectations(
+    model_name="Llama-3.2-3B-Instruct",
+    n_layers=28,  # Llama-3.2-3B-Instruct has 28 layers (registry default for llama3)
+    n_heads=24,
+    n_kv_heads=8,  # GQA
+    d_model=3072,
+    has_pos_embed=False,  # RoPE
+    has_gate_proj=True,  # SwiGLU
+    has_biases=False,
+    # Canonical patterns for Llama3 (HF-style wrapped in TransformerBridge)
+    canonical_attn_pattern=r"model\.layers\.\d+\.self_attn\.(q_proj|k_proj|v_proj|o_proj)\.weight",
+    canonical_mlp_pattern=r"model\.layers\.\d+\.mlp\.(gate_proj|up_proj|down_proj)\.weight",
+    canonical_embed_pattern=r"model\.(embed_tokens|lm_head)\.weight",
+    # Mapping counts: 368 TL params total (includes synthetic biases from TransformerBridge)
+    # 28 layers * (4 attn weights + 4 attn biases + 3 mlp weights + 3 mlp biases)
+    # + 2 embed + 1 pos_embed + 2 unembed = 368
+    # 199 of these map to canonical (weights only, biases are synthetic)
+    # Canonical: 198 mapped (lm_head weight is shared with embed)
+    # + 57 LayerNorms (28 * 2 + 1 final) = 255 total
+    expected_mapped_tl_count=199,
+    expected_unmapped_tl_count=169,  # Synthetic biases and pos_embed don't map to canonical
+    expected_mapped_canonical_count=198,  # lm_head weight is shared with embed
+    expected_unmapped_canonical_count=57,  # LayerNorms (input_layernorm, post_attention_layernorm, norm)
+)
+
+GEMMA2_EXPECTATIONS = ArchitectureExpectations(
+    model_name="Gemma-2-2B",
+    n_layers=26,
+    n_heads=8,
+    n_kv_heads=4,  # GQA
+    d_model=2304,
+    has_pos_embed=False,  # RoPE
+    has_gate_proj=True,  # GeGLU
+    has_biases=False,
+    # Canonical patterns for Gemma2 (HF-style wrapped in TransformerBridge)
+    canonical_attn_pattern=r"model\.layers\.\d+\.self_attn\.(q_proj|k_proj|v_proj|o_proj)\.weight",
+    canonical_mlp_pattern=r"model\.layers\.\d+\.mlp\.(gate_proj|up_proj|down_proj)\.weight",
+    canonical_embed_pattern=r"model\.(embed_tokens)\.weight",
+    # Mapping counts: 342 TL params total (includes synthetic biases from TransformerBridge)
+    # 26 layers * (4 attn weights + 4 attn biases + 3 mlp weights + 3 mlp biases)
+    # + 1 embed + 1 pos_embed + 2 unembed = 342
+    # 185 of these map to canonical (weights only, biases are synthetic)
+    # Canonical: 184 mapped (lm_head weight shares with embed)
+    # + 105 LayerNorms (26 * 4 + 1 final) = 289 total
+    expected_mapped_tl_count=185,
+    expected_unmapped_tl_count=157,  # Synthetic biases and pos_embed don't map to canonical
+    expected_mapped_canonical_count=184,  # lm_head weight shares with embed
+    expected_unmapped_canonical_count=105,  # LayerNorms (input_layernorm,
+    # post_attention_layernorm, pre_feedforward_layernorm, post_feedforward_layernorm, norm)
+)
+
+# GPT-2 small architecture expectations
+GPT2_EXPECTATIONS = ArchitectureExpectations(
+    model_name="GPT-2",
+    n_layers=12,
+    n_heads=12,
+    n_kv_heads=12,  # MHA (same as n_heads)
+    d_model=768,
+    has_pos_embed=True,  # Learned position embeddings
+    has_gate_proj=False,  # No gated MLP
+    has_biases=True,
+    # GPT-2 specific TL params include biases
+    expected_tl_attn_params=[
+        "attn.W_Q",
+        "attn.W_K",
+        "attn.W_V",
+        "attn.W_O",
+        "attn.b_Q",
+        "attn.b_K",
+        "attn.b_V",
+        "attn.b_O",
+    ],
+    expected_tl_mlp_params=["mlp.W_in", "mlp.W_out", "mlp.b_in", "mlp.b_out"],
+    expected_tl_embed_params=["embed.W_E", "pos_embed.W_pos", "unembed.W_U"],
+    # Canonical patterns for GPT-2 (TransformerBridge wrapped)
+    canonical_attn_pattern=r"model\.blocks\.\d+\._original_component\.attn\.(q|k|v|o)\._original_component\.(weight|bias)",
+    canonical_mlp_pattern=r"model\.blocks\.\d+\._original_component\.mlp\._original_component\.(c_fc|c_proj)\._original_component\.(weight|bias)",
+    canonical_embed_pattern=r"model\.(embed|pos_embed|unembed)\._original_component\.(weight|bias)",
+    # Mapping counts: 12 layers * (8 attn + 4 mlp) + 4 embed/pos_embed/unembed = 148 TL params
+    # Canonical: 171 mapped (148 TL + 24 from q/k/v split components) + 50 unmapped - 1 shared embed/unembed = 221 total
+    # Unmapped: 50 LayerNorms (12*4 + 2 ln_final) (all QKV joint params remain mapped along with split views)
+    expected_mapped_tl_count=148,
+    expected_unmapped_tl_count=0,
+    expected_mapped_canonical_count=171,  # 148 TL + 24 q/k/v split components - 1 shared embed/unembed
+    expected_unmapped_canonical_count=50,  # 50 LayerNorm params (QKV joint params remain mapped)
+)
+
+# GPT-2 with weight processing enabled (fold_ln=True, fold_value_biases=True, center_writing_weights=True, etc.)
+# LN params aren't represented with TL style names (whether folded or not).
+# This tests the mapping behavior when TL processing transformations are applied.
+GPT2_PROCESSED_EXPECTATIONS = ArchitectureExpectations(
+    model_name="GPT-2 (processed)",
+    n_layers=12,
+    n_heads=12,
+    n_kv_heads=12,
+    d_model=768,
+    has_pos_embed=True,
+    has_gate_proj=False,
+    has_biases=True,
+    # LayerNorm params do not appear in TL params
+    # When fold_value_biases=True, value biases are folded into output bias
+    expected_tl_attn_params=[
+        "attn.W_Q",
+        "attn.W_K",
+        "attn.W_V",
+        "attn.W_O",
+        "attn.b_Q",
+        "attn.b_K",
+        "attn.b_V",
+        "attn.b_O",
+    ],
+    expected_tl_mlp_params=["mlp.W_in", "mlp.W_out", "mlp.b_in", "mlp.b_out"],
+    expected_tl_embed_params=["embed.W_E", "pos_embed.W_pos", "unembed.W_U"],
+    canonical_attn_pattern=r"model\.blocks\.\d+\._original_component\.attn\.(q|k|v|o)\._original_component\.(weight|bias)",
+    canonical_mlp_pattern=r"model\.blocks\.\d+\._original_component\.mlp\._original_component\.(c_fc|c_proj)\._original_component\.(weight|bias)",
+    canonical_embed_pattern=r"model\.(embed|pos_embed|unembed)\._original_component\.(weight|bias)",
+    # Mapping counts same as unprocessed GPT-2
+    # 12 layers * (8 attn + 4 mlp) + 4 embed/pos_embed/unembed = 148 TL params
+    # Compatible mode adds extra canonical params: 222 total (vs 221 for unprocessed)
+    # Canonical: 148 TL mapped + 74 unmapped = 222 total (embed/unembed not shared with processed mode)
+    # Unmapped: 50 LayerNorms (12*4 + 2 ln_final) + 24 QKV joints (12*2)
+    expected_mapped_tl_count=148,
+    expected_unmapped_tl_count=0,
+    expected_mapped_canonical_count=148,
+    expected_unmapped_canonical_count=74,  # 50 LayerNorm params + 24 QKV joint params (compatible mode)
+)
 
 
 class TestClassTransformerLens:
@@ -79,7 +273,7 @@ class TestClassTransformerLens:
     def test_tl_session_cfg_exceptions(self):
         test_tl_cfg = deepcopy(TestClassTransformerLens.test_tlens_cust)
         test_tl_cfg.update({"tl_cfg": None})
-        with pytest.raises(MisconfigurationException, match="Either a `ITLens"):
+        with pytest.raises(MisconfigurationException, match="A valid tl_cfg"):
             _ = ITLensConfig(**test_tl_cfg)
 
     @pytest.mark.parametrize(
@@ -204,15 +398,626 @@ class TestClassTransformerLens:
         assert it_cfg_custom_override.tl_cfg.use_bridge is False
 
 
-def test_transformerbridge_adapter_basic_properties():
-    """Sanity check for TransformerBridgeStrategyAdapter plugin.
+class TestBasicTransformerBridgeAdapter:
+    """Basic tests for TransformerBridgeStrategyAdapter without model fixtures.
 
-    This ensures the adapter is well-formed and provides the hooks required by FTS restore logic.
+    These tests validate adapter initialization, properties, and basic behavior without requiring actual
+    TransformerBridge model instantiation.
     """
-    assert issubclass(TransformerBridgeStrategyAdapter, StrategyAdapter)
-    methods = inspect.getmembers(TransformerBridgeStrategyAdapter, predicate=inspect.isfunction)
-    method_names = {n for n, _ in methods}
-    # Should implement the adapter's before_restore_model hook (new preferred name) and backward compat alias
-    assert "before_restore_model" in method_names
-    assert "fts_optim_transform" in method_names
-    assert "logical_param_translation" in method_names
+
+    def test_basic_properties(self):
+        """Sanity check for TransformerBridgeStrategyAdapter plugin.
+
+        This ensures the adapter is well-formed and provides the hooks required by FTS restore logic.
+        """
+        assert issubclass(TransformerBridgeStrategyAdapter, StrategyAdapter)
+        methods = inspect.getmembers(TransformerBridgeStrategyAdapter, predicate=inspect.isfunction)
+        method_names = {n for n, _ in methods}
+        # Should implement the adapter's before_restore_model hook (new preferred name) and backward compat alias
+        assert "before_restore_model" in method_names
+        assert "fts_optim_transform" in method_names
+        assert "logical_param_translation" in method_names
+
+    @pytest.mark.parametrize("use_tl_names", [True, False])
+    def test_initialization(self, use_tl_names):
+        """Test TransformerBridgeStrategyAdapter initialization with use_tl_names flag."""
+        adapter = TransformerBridgeStrategyAdapter(use_tl_names=use_tl_names)
+        assert adapter._use_tl_names == use_tl_names
+        assert adapter.model_view is None  # Not initialized until on_before_init_fts
+
+    def test_tl_names_disabled(self):
+        """Test that CanonicalModelView is used when use_tl_names=False."""
+        adapter = TransformerBridgeStrategyAdapter(use_tl_names=False)
+
+        # Verify initialization state
+        assert adapter._use_tl_names is False
+        assert adapter.model_view is None  # Not initialized until on_before_init_fts
+
+        # The actual delegation behavior is tested via the full test_bidirectional_mapping
+        # tests with real ITLens modules
+
+    @pytest.mark.parametrize(
+        "tl_name,expected_canonical_pattern",
+        [
+            ("blocks.9.attn.W_Q", "model.blocks.9._original_component.attn.q._original_component.weight"),
+            ("blocks.9.attn.b_Q", "model.blocks.9._original_component.attn.q._original_component.bias"),
+            ("blocks.0.mlp.W_in", "model.blocks.0._original_component.mlp._original_component.0.weight"),
+            ("embed.W_E", "model.embed._original_component.weight"),
+            ("unembed.W_U", "model.unembed.W_U"),
+        ],
+        ids=["attn_weight", "attn_bias", "mlp_weight", "embed", "unembed"],
+    )
+    def test_naming_patterns(self, tl_name, expected_canonical_pattern):
+        """Test expected naming patterns between TL-style and canonical names."""
+        # This test documents the expected naming conventions
+        # Actual mapping is built from tensor data_ptr() matching, not string patterns
+        assert "blocks" in tl_name or "embed" in tl_name or "unembed" in tl_name
+        assert "_original_component" in expected_canonical_pattern or expected_canonical_pattern == "model.unembed.W_U"
+
+    def test_inspect_state(self):
+        """Test that inspect_state utility is available as static method."""
+        assert hasattr(TransformerBridgeStrategyAdapter, "inspect_state")
+        assert callable(TransformerBridgeStrategyAdapter.inspect_state)
+
+    def test_gen_ft_schedule_disabled(self):
+        """Test gen_ft_schedule delegates to parent when use_tl_names=False."""
+        adapter = TransformerBridgeStrategyAdapter(use_tl_names=False)
+
+        # Without a pl_module set, calling parent gen_ft_schedule should work (uses default implementation)
+        # The actual schedule generation is tested in integration tests
+        assert hasattr(adapter, "gen_ft_schedule")
+        assert callable(adapter.gen_ft_schedule)
+
+
+# =============================================================================
+# Parameter Mapping Validation Tests
+# =============================================================================
+
+
+class TestArchitectureParameterMapping:
+    """Parameterized architecture parameter mapping tests.
+
+    Validates TL-style parameter naming and bidirectional mapping for multiple architectures:
+    - GPT-2: MHA, learned pos_embed, biases (non-standalone, fast)
+    - Llama3: GQA, SwiGLU, RMSNorm, RoPE (standalone)
+    - Gemma2: GQA, GeGLU, RMSNorm, sliding window attention (standalone)
+
+    Uses ArchitectureExpectations dataclass for per-model validation criteria.
+    Validates the component-tracing approach in TransformerBridgeStrategyAdapter.
+
+    Also includes tests for validating TL-style to canonical parameter mapping functionality:
+    - TL-style names (e.g., blocks.9.attn.W_Q, embed.W_E)
+    - Canonical names (e.g., model.blocks.9._original_component.attn.q._original_component.weight)
+
+    The mapping must be:
+    1. Complete: All TL params should map to canonical params
+    2. Invertible: Canonical params should map back to TL params
+    3. Architecture-invariant: Work across GPT-2, Llama, Gemma, etc.
+    """
+
+    # Expected TL-style parameter patterns for different component types
+    TL_ATTENTION_PATTERNS = {
+        r"blocks\.\d+\.attn\.W_Q",
+        r"blocks\.\d+\.attn\.W_K",
+        r"blocks\.\d+\.attn\.W_V",
+        r"blocks\.\d+\.attn\.W_O",
+        r"blocks\.\d+\.attn\.b_Q",
+        r"blocks\.\d+\.attn\.b_K",
+        r"blocks\.\d+\.attn\.b_V",
+        r"blocks\.\d+\.attn\.b_O",
+    }
+
+    TL_MLP_PATTERNS = {
+        r"blocks\.\d+\.mlp\.W_in",
+        r"blocks\.\d+\.mlp\.W_out",
+        r"blocks\.\d+\.mlp\.b_in",
+        r"blocks\.\d+\.mlp\.b_out",
+        # Gated MLPs (Llama, Gemma)
+        r"blocks\.\d+\.mlp\.W_gate",
+        r"blocks\.\d+\.mlp\.b_gate",
+    }
+
+    TL_EMBEDDING_PATTERNS = {
+        r"embed\.W_E",
+        r"pos_embed\.W_pos",
+        r"unembed\.W_U",
+        r"unembed\.b_U",
+    }
+
+    TL_LAYERNORM_PATTERNS = {
+        r"blocks\.\d+\.ln1\.w",
+        r"blocks\.\d+\.ln1\.b",
+        r"blocks\.\d+\.ln2\.w",
+        r"blocks\.\d+\.ln2\.b",
+        r"ln_final\.w",
+        r"ln_final\.b",
+    }
+
+    @staticmethod
+    def get_tl_params_from_bridge(bridge) -> Dict[str, torch.Tensor]:
+        """Get TL-style parameters from a TransformerBridge instance."""
+        return dict(bridge.tl_named_parameters())
+
+    @staticmethod
+    def get_canonical_params_from_module(module) -> Dict[str, torch.Tensor]:
+        """Get canonical parameters from a LightningModule."""
+        return dict(module.named_parameters())
+
+    @staticmethod
+    def categorize_tl_param(name: str) -> str:
+        """Categorize a TL-style parameter name by component type."""
+        if ".attn." in name:
+            return "attention"
+        elif ".mlp." in name:
+            return "mlp"
+        elif "embed" in name or "unembed" in name:
+            return "embedding"
+        elif "ln" in name:
+            return "layernorm"
+        else:
+            return "other"
+
+    @staticmethod
+    def validate_mapping_structure(tl_to_canonical: Dict, canonical_to_tl: Dict) -> Dict[str, Set[str]]:
+        """Validate the structure of bidirectional mappings.
+
+        Returns:
+            Dict with 'unmapped_tl', 'unmapped_canonical', 'multi_mapped_canonical' sets
+        """
+        issues = {
+            "unmapped_tl": set(),
+            "unmapped_canonical": set(),
+            "multi_mapped_canonical": set(),
+        }
+
+        # Check for unmapped TL params
+        for tl_name, canonical_list in tl_to_canonical.items():
+            if not canonical_list:
+                issues["unmapped_tl"].add(tl_name)
+
+        # Check for canonical params with multiple TL mappings (which is OK for views)
+        canonical_counts = {}
+        for canonical_name, tl_name in canonical_to_tl.items():
+            if tl_name not in canonical_counts:
+                canonical_counts[tl_name] = []
+            canonical_counts[tl_name].append(canonical_name)
+
+        # Multi-mapping is expected for views, but log for awareness
+        for tl_name, canonical_list in canonical_counts.items():
+            if len(canonical_list) > 1:
+                issues["multi_mapped_canonical"].add(tl_name)
+
+        return issues
+
+    def test_tl_param_pattern_coverage(self):
+        """Test that TL-style parameter patterns are comprehensive."""
+        # Verify pattern sets are non-empty and well-formed
+        assert len(self.TL_ATTENTION_PATTERNS) >= 8
+        assert len(self.TL_MLP_PATTERNS) >= 4
+        assert len(self.TL_EMBEDDING_PATTERNS) >= 2
+
+        # Verify patterns compile without error
+        all_patterns = (
+            self.TL_ATTENTION_PATTERNS | self.TL_MLP_PATTERNS | self.TL_EMBEDDING_PATTERNS | self.TL_LAYERNORM_PATTERNS
+        )
+        for pattern in all_patterns:
+            compiled = re.compile(pattern)
+            assert compiled is not None
+
+    def test_param_categorization(self):
+        """Test that parameter categorization works correctly."""
+        test_cases = [
+            ("blocks.0.attn.W_Q", "attention"),
+            ("blocks.11.attn.b_O", "attention"),
+            ("blocks.5.mlp.W_in", "mlp"),
+            ("blocks.5.mlp.W_gate", "mlp"),
+            ("embed.W_E", "embedding"),
+            ("unembed.W_U", "embedding"),
+            ("pos_embed.W_pos", "embedding"),
+            ("blocks.0.ln1.w", "layernorm"),
+            ("ln_final.w", "layernorm"),
+        ]
+
+        for param_name, expected_category in test_cases:
+            actual = self.categorize_tl_param(param_name)
+            assert actual == expected_category, f"Expected {expected_category} for {param_name}, got {actual}"
+
+    def _validate_tl_param_structure(
+        self, bridge, module, arch_expectations: ArchitectureExpectations
+    ) -> Tuple[Dict, Dict]:
+        """Verify TransformerBridge has expected TL-style parameter structure.
+
+        Validates:
+        - Non-empty parameters
+        - Correct number of layers
+        - All expected attention params per layer
+        - All expected MLP params per layer
+        - All expected embedding params
+
+        Args:
+            bridge: TransformerBridge model
+            module: Lightning module wrapping the model
+            arch_expectations: Expected architecture parameters
+
+        Returns:
+            Tuple of (tl_params, canonical_params) dicts for further validation
+        """
+        tl_params = dict(bridge.tl_named_parameters())
+        canonical_params = dict(module.named_parameters())
+
+        # ===== Basic Structure Validation =====
+        assert len(tl_params) > 0, f"[{arch_expectations.model_name}] No TL-style parameters found"
+        assert len(canonical_params) > 0, f"[{arch_expectations.model_name}] No canonical parameters found"
+
+        # ===== Layer Count Validation =====
+        layer_indices = set()
+        for name in tl_params.keys():
+            match = re.match(r"blocks\.(\d+)\.", name)
+            if match:
+                layer_indices.add(int(match.group(1)))
+
+        assert len(layer_indices) == arch_expectations.n_layers, (
+            f"[{arch_expectations.model_name}] Expected {arch_expectations.n_layers} layers, found {len(layer_indices)}"
+        )
+
+        # ===== Attention Parameter Validation =====
+        for attn_suffix in arch_expectations.expected_tl_attn_params:
+            param_name = f"blocks.0.{attn_suffix}"
+            assert param_name in tl_params, f"[{arch_expectations.model_name}] Missing attention param: {param_name}"
+
+        # ===== MLP Parameter Validation =====
+        for mlp_suffix in arch_expectations.expected_tl_mlp_params:
+            param_name = f"blocks.0.{mlp_suffix}"
+            assert param_name in tl_params, f"[{arch_expectations.model_name}] Missing MLP param: {param_name}"
+
+        # ===== Embedding Parameter Validation =====
+        for embed_param in arch_expectations.expected_tl_embed_params:
+            assert embed_param in tl_params, f"[{arch_expectations.model_name}] Missing embedding param: {embed_param}"
+
+        # Check position embeddings based on architecture
+        if arch_expectations.has_pos_embed:
+            assert "pos_embed.W_pos" in tl_params, (
+                f"[{arch_expectations.model_name}] Expected pos_embed.W_pos but not found"
+            )
+
+        # ===== Parameter Count Summary =====
+        tl_count = len(tl_params)
+        canonical_count = len(canonical_params)
+        print(f"[{arch_expectations.model_name}] Parameter counts - TL: {tl_count}, Canonical: {canonical_count}")
+
+        return tl_params, canonical_params
+
+    @pytest.mark.parametrize(
+        "session_fixture, arch_expectations",
+        [
+            pytest.param(
+                "get_it_session__l_tl_bridge_gpt2__setup",
+                GPT2_EXPECTATIONS,
+                id="gpt2",
+            ),
+            pytest.param(
+                "get_it_session__l_tl_bridge_gpt2_processed__setup",
+                GPT2_PROCESSED_EXPECTATIONS,
+                id="gpt2_processed",
+            ),
+            pytest.param(
+                "get_it_session__l_tl_bridge_llama3__setup",
+                LLAMA3_EXPECTATIONS,
+                marks=RunIf(standalone=True, bf16_cuda=True),
+                id="llama3",
+            ),
+            pytest.param(
+                "get_it_session__l_tl_bridge_gemma2__setup",
+                GEMMA2_EXPECTATIONS,
+                marks=RunIf(standalone=True, bf16_cuda=True),
+                id="gemma2",
+            ),
+        ],
+    )
+    def test_bidirectional_mapping(self, request, session_fixture: str, arch_expectations: ArchitectureExpectations):
+        """Validate bidirectional TL ↔ canonical parameter mapping using component tracing.
+
+        First validates TL parameter structure as a precondition, then tests the
+        TransformerBridgeStrategyAdapter's _build_param_mapping() method which uses
+        component structure tracing to build mappings.
+
+        Validates:
+        - TL parameter structure (layer count, attention/MLP/embedding params)
+        - All non-LayerNorm TL params have canonical mappings
+        - Canonical params without TL equivalents are expected (joint QKV, etc.)
+        - Mapping is consistent (same param doesn't map to multiple TL names)
+        """
+        fixture = request.getfixturevalue(session_fixture)
+        module = fixture.it_session.module
+        bridge = module.model
+
+        # ===== Precondition: Validate TL param structure =====
+        tl_params, canonical_params = self._validate_tl_param_structure(bridge, module, arch_expectations)
+
+        # ===== Build param mapping using component tracing =====
+        adapter = TransformerBridgeStrategyAdapter(use_tl_names=True)
+
+        # Create a mock fts_handle to provide pl_module and trainer access
+        class MockTrainer:
+            pass  # Minimal trainer stub
+
+        class MockFTSHandle:
+            def __init__(self, pl_module):
+                self.pl_module = pl_module
+                self.trainer = MockTrainer()
+
+        adapter.fts_handle = MockFTSHandle(module)
+
+        # Build the parameter mapping using component tracing
+        # (ModelView gets created in on_before_init_fts)
+        adapter.on_before_init_fts()
+
+        assert adapter.model_view is not None, "ModelView not created"
+        tl_to_canonical = adapter.model_view._tl_to_canonical_mapping
+        canonical_to_tl = adapter.model_view._canonical_to_tl_mapping
+
+        assert tl_to_canonical is not None, "TL to canonical mapping not built"
+        assert canonical_to_tl is not None, "Canonical to TL mapping not built"
+
+        # ===== TL → Canonical Mapping Validation =====
+        unmapped_tl = []
+        mapped_tl_count = 0
+        for tl_name in tl_params.keys():
+            canonical_names = tl_to_canonical.get(tl_name, [])
+            if canonical_names:
+                mapped_tl_count += 1
+                # Verify canonical names actually exist
+                for cn in canonical_names:
+                    assert cn in canonical_params, (
+                        f"[{arch_expectations.model_name}] TL '{tl_name}' maps to non-existent canonical '{cn}'"
+                    )
+            else:
+                unmapped_tl.append(tl_name)
+
+        print(
+            f"[{arch_expectations.model_name}] TL→Canonical: {mapped_tl_count}/{len(tl_params)} mapped, "
+            f"{len(unmapped_tl)} unmapped"
+        )
+
+        # Validate exact mapping counts - ALL TL params should be mapped
+        assert mapped_tl_count == arch_expectations.expected_mapped_tl_count, (
+            f"[{arch_expectations.model_name}] TL mapping count mismatch: "
+            f"expected {arch_expectations.expected_mapped_tl_count}, got {mapped_tl_count}"
+        )
+        assert len(unmapped_tl) == arch_expectations.expected_unmapped_tl_count, (
+            f"[{arch_expectations.model_name}] Unmapped TL count mismatch: "
+            f"expected {arch_expectations.expected_unmapped_tl_count}, got {len(unmapped_tl)}. "
+            f"Unmapped: {unmapped_tl[:10]}"
+        )
+
+        # ===== Canonical → TL Mapping Validation =====
+        mapped_canonical_count = len(canonical_to_tl)
+        unmapped_canonical = [k for k in canonical_params.keys() if k not in canonical_to_tl]
+
+        print(
+            f"[{arch_expectations.model_name}] Canonical→TL: {mapped_canonical_count}/{len(canonical_params)} mapped, "
+            f"{len(unmapped_canonical)} unmapped"
+        )
+
+        # Validate exact mapping counts for canonical params
+        assert mapped_canonical_count == arch_expectations.expected_mapped_canonical_count, (
+            f"[{arch_expectations.model_name}] Canonical mapping count mismatch: "
+            f"expected {arch_expectations.expected_mapped_canonical_count}, got {mapped_canonical_count}"
+        )
+        assert len(unmapped_canonical) == arch_expectations.expected_unmapped_canonical_count, (
+            f"[{arch_expectations.model_name}] Unmapped canonical count mismatch: "
+            f"expected {arch_expectations.expected_unmapped_canonical_count}, got {len(unmapped_canonical)}. "
+            f"Unmapped: {unmapped_canonical[:10]}"
+        )
+
+        # Many canonical params won't have TL equivalents (LayerNorms, joint QKV, original components, etc.)
+        # This is expected - we just validate that the reverse mapping is consistent
+        for canonical_name, tl_name in canonical_to_tl.items():
+            assert tl_name in tl_params, (
+                f"[{arch_expectations.model_name}] Canonical '{canonical_name}' maps to non-existent TL '{tl_name}'"
+            )
+            # Verify bidirectional consistency
+            assert canonical_name in tl_to_canonical.get(tl_name, []), (
+                f"[{arch_expectations.model_name}] Bidirectional inconsistency: "
+                f"canonical '{canonical_name}' → TL '{tl_name}' but TL doesn't map back"
+            )
+
+
+# =============================================================================
+# Custom ModelView Tests
+# =============================================================================
+
+
+class TestCustomModelView:
+    """Tests for custom ModelView usage."""
+
+    def test_custom_model_view(self, get_it_session__l_tl_bridge_gpt2__setup):
+        """Test that a simple custom ModelView can be successfully instantiated and used."""
+        from interpretune.adapters.model_view import ModelView
+        import os
+        from typing import Dict, List, Optional, Union
+
+        # Define a simple custom ModelView that prefixes all param names
+        class PrefixedModelView(ModelView):
+            """Test view that adds 'custom_' prefix to all parameter names."""
+
+            def __init__(self, adapter):
+                super().__init__(adapter)
+                self.prefix = "custom_"
+
+            def build_param_mapping(self) -> None:
+                """No complex mapping needed for this simple test."""
+                pass
+
+            def transform_to_canonical(self, param_names: List[str], inspect_only: bool = False) -> List[str]:
+                """Strip custom prefix to get canonical names."""
+                return [
+                    name.replace(self.prefix, "", 1) if name.startswith(self.prefix) else name for name in param_names
+                ]
+
+            def transform_from_canonical(self, param_names: List[str]) -> List[str]:
+                """Add custom prefix to canonical names."""
+                return [f"{self.prefix}{name}" for name in param_names]
+
+            def get_named_params(self) -> Dict[str, torch.Tensor]:
+                """Get params with custom prefix."""
+                return {f"{self.prefix}{name}": param for name, param in self.pl_module.named_parameters()}
+
+            def gen_schedule(self, dump_loc: Union[str, os.PathLike]) -> Optional[os.PathLike]:
+                """Not tested in this simple test."""
+                return None
+
+            def validate_schedule(self) -> None:
+                """Not tested in this simple test."""
+                pass
+
+        # Get the fixture
+        fixture = get_it_session__l_tl_bridge_gpt2__setup
+        module = fixture.it_session.module
+
+        # Create adapter with custom ModelView class
+        adapter = TransformerBridgeStrategyAdapter(model_view=PrefixedModelView)
+
+        # Create mock FTS handle
+        class MockFTSHandle:
+            def __init__(self, pl_module):
+                self.pl_module = pl_module
+
+        class MockTrainer:
+            pass
+
+        adapter.fts_handle = MockFTSHandle(module)
+        adapter.fts_handle.trainer = MockTrainer()
+
+        # Initialize the model view
+        adapter.on_before_init_fts()
+
+        # Verify custom ModelView was created
+        assert adapter.model_view is not None
+        assert isinstance(adapter.model_view, PrefixedModelView)
+
+        # Test transformations
+        canonical_params = ["model.embed.weight", "model.blocks.0.attn.W_Q"]
+
+        # Transform to canonical (should strip prefix)
+        prefixed_params = adapter.model_view.transform_from_canonical(canonical_params)
+        assert all(p.startswith("custom_") for p in prefixed_params)
+        assert prefixed_params == ["custom_model.embed.weight", "custom_model.blocks.0.attn.W_Q"]
+
+        # Transform back to canonical (should remove prefix)
+        back_to_canonical = adapter.model_view.transform_to_canonical(prefixed_params)
+        assert back_to_canonical == canonical_params
+
+        # Test get_named_params returns prefixed names
+        named_params = adapter.model_view.get_named_params()
+        assert all(name.startswith("custom_") for name in named_params.keys())
+        assert len(named_params) > 0  # Should have some parameters
+
+
+class TestImplicitLayerNormThawing:
+    """Test implicit LayerNorm thawing configuration in TLNamesModelView."""
+
+    def test_implicit_ln_thaw_default(self, get_it_session__l_tl_bridge_gpt2__setup):
+        """Test that implicit_ln_thaw defaults to True (existing behavior)."""
+        fixture = get_it_session__l_tl_bridge_gpt2__setup
+        module = fixture.it_session.module
+
+        # Create adapter with use_tl_names=True (creates TLNamesModelView)
+        adapter = TransformerBridgeStrategyAdapter(use_tl_names=True)
+
+        # Set up the adapter
+        class MockFTSHandle:
+            def __init__(self, pl_module):
+                self.pl_module = pl_module
+
+        class MockTrainer:
+            pass
+
+        adapter.fts_handle = MockFTSHandle(module)
+        adapter.fts_handle.trainer = MockTrainer()
+        adapter.on_before_init_fts()
+
+        # Default adapter with use_tl_names=True should have TLNamesModelView with implicit_ln_thaw=True
+        assert hasattr(adapter.model_view, "implicit_ln_thaw"), (
+            "TLNamesModelView should have implicit_ln_thaw attribute"
+        )
+        assert adapter.model_view.implicit_ln_thaw is True
+
+        # Test that LayerNorm params are included when thawing attention blocks
+        tl_params = ["blocks.0.attn.W_Q", "blocks.0.attn.W_K"]
+        canonical_params = adapter.model_view.transform_to_canonical(tl_params)
+
+        # Should include ln_1 and ln_2 for block 0
+        ln_params = [p for p in canonical_params if "ln_1" in p or "ln_2" in p]
+        assert len(ln_params) > 0, "Should include implicit LayerNorm params with implicit_ln_thaw=True"
+
+    def test_implicit_ln_thaw_disabled(self, get_it_session__l_tl_bridge_gpt2__setup):
+        """Test that implicit_ln_thaw=False disables LayerNorm thawing."""
+        fixture = get_it_session__l_tl_bridge_gpt2__setup
+        module = fixture.it_session.module
+
+        # Create new adapter with implicit_ln_thaw=False
+        adapter = TransformerBridgeStrategyAdapter(use_tl_names=True, model_view_cfg={"implicit_ln_thaw": False})
+
+        # Set up the adapter
+        class MockFTSHandle:
+            def __init__(self, pl_module):
+                self.pl_module = pl_module
+
+        class MockTrainer:
+            pass
+
+        adapter.fts_handle = MockFTSHandle(module)
+        adapter.fts_handle.trainer = MockTrainer()
+        adapter.on_before_init_fts()
+
+        # Verify implicit_ln_thaw is False
+        assert adapter.model_view.implicit_ln_thaw is False
+
+        # Test that LayerNorm params are NOT included
+        tl_params = ["blocks.0.attn.W_Q", "blocks.0.attn.W_K"]
+        canonical_params = adapter.model_view.transform_to_canonical(tl_params)
+
+        # Should NOT include ln_1 or ln_2 for block 0
+        ln_params = [p for p in canonical_params if "ln_1" in p or "ln_2" in p]
+        assert len(ln_params) == 0, "Should not include LayerNorm params with implicit_ln_thaw=False"
+
+        # Verify only the requested TL params were transformed
+        # Each TL param may map to one or more canonical params (e.g., weight and bias)
+        assert len(canonical_params) >= len(tl_params), "Should have at least the requested params"
+
+    def test_implicit_ln_thaw_with_model_view_class(self, get_it_session__l_tl_bridge_gpt2__setup):
+        """Test passing model_view_cfg when using model_view parameter."""
+        fixture = get_it_session__l_tl_bridge_gpt2__setup
+        module = fixture.it_session.module
+
+        # Import TLNamesModelView
+        from interpretune.adapters.transformer_lens import TLNamesModelView
+
+        # Create adapter with model_view class and config
+        adapter = TransformerBridgeStrategyAdapter(
+            model_view=TLNamesModelView, model_view_cfg={"implicit_ln_thaw": False}
+        )
+
+        # Set up the adapter
+        class MockFTSHandle:
+            def __init__(self, pl_module):
+                self.pl_module = pl_module
+
+        class MockTrainer:
+            pass
+
+        adapter.fts_handle = MockFTSHandle(module)
+        adapter.fts_handle.trainer = MockTrainer()
+        adapter.on_before_init_fts()
+
+        # Verify config was passed correctly
+        assert adapter.model_view.implicit_ln_thaw is False
+
+        # Test transformation
+        tl_params = ["blocks.0.mlp.W_in"]
+        canonical_params = adapter.model_view.transform_to_canonical(tl_params)
+
+        # Should NOT include LayerNorm params
+        ln_params = [p for p in canonical_params if "ln_" in p]
+        assert len(ln_params) == 0, "Should not include LayerNorm params"

--- a/tests/modules.py
+++ b/tests/modules.py
@@ -19,6 +19,7 @@ from transformers.utils import ModelOutput
 from interpretune.protocol import ITModuleProtocol, STEP_OUTPUT
 from interpretune.config import ITDataModuleConfig, ITConfig
 from interpretune.utils import rank_zero_only, rank_zero_debug
+from interpretune import MemProfilerHooks
 from it_examples.experiments.rte_boolq import RTEBoolqDataModule, RTEBoolqModuleMixin, RTEBoolqSteps
 from tests import FinetuningScheduler
 from tests.base_defaults import default_test_task
@@ -424,15 +425,82 @@ class StateLogInspectMixin:
                 memory_footprints[parity_normalize(self.test_alias)]["expected_mem"][act] = actual_val
 
 
+class DivergeOnEpochMixin:
+    """Mixin that adds diverging loss behavior starting at a specified epoch.
+
+    This mixin overrides training_step and validation_step to blend real logits with fake (zeros) logits based on
+    current_epoch/max_epochs ratio, causing gradual loss divergence.
+    """
+
+    def __init__(self, *args, diverge_on_epoch: Optional[int] = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        it_cfg = reduce(lambda o, a: getattr(o, a, None), ("it_cfg", "model_cfg"), self)
+        self.diverge_on_epoch = it_cfg.get("diverge_on_epoch", diverge_on_epoch) if it_cfg else diverge_on_epoch
+
+    def _before_it_cfg_init(self, it_cfg: ITConfig) -> ITConfig:
+        it_cfg = super()._before_it_cfg_init(it_cfg) if hasattr(super(), "_before_it_cfg_init") else it_cfg
+        if it_cfg.model_cfg and "diverge_on_epoch" in it_cfg.model_cfg:
+            self.diverge_on_epoch = it_cfg.model_cfg.get("diverge_on_epoch", None)
+        if self.diverge_on_epoch is not None:
+            rank_zero_debug(f"Divergence enabled: will diverge starting at epoch {self.diverge_on_epoch}")
+        return it_cfg
+
+    def _compute_diverging_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        """Compute loss with gradual divergence based on current_epoch to max_epochs ratio.
+
+        Blends real logits with fake (zeros) logits to cause increasing loss. The ratio increases from 0 at
+        diverge_on_epoch to 1 at max_epochs.
+        """
+        if (
+            self.diverge_on_epoch is not None
+            and hasattr(self, "current_epoch")
+            and self.current_epoch >= self.diverge_on_epoch
+        ):
+            # Calculate divergence ratio based on progress from diverge_on_epoch to max_epochs
+            max_epochs = self.trainer.max_epochs if hasattr(self, "trainer") else 5
+            # Add 1 to epochs_diverging so that at diverge_on_epoch we get ratio > 0
+            # Example: diverge_on_epoch=2, max_epochs=5
+            #   epoch 2: (2-2+1) / (5-2) = 1/3 = 0.333
+            #   epoch 3: (3-2+1) / (5-2) = 2/3 = 0.667
+            #   epoch 4: (4-2+1) / (5-2) = 3/3 = 1.0
+            epochs_diverging = self.current_epoch - self.diverge_on_epoch + 1
+            total_diverge_epochs = max(max_epochs - self.diverge_on_epoch, 1)
+            diverge_ratio = min(epochs_diverging / total_diverge_epochs, 1.0)
+
+            # Blend real logits with zeros to cause gradual divergence
+            fake_logits = torch.zeros_like(logits)
+            blended_logits = (1 - diverge_ratio) * logits + diverge_ratio * fake_logits
+
+            rank_zero_debug(
+                f"Epoch {self.current_epoch} >= {self.diverge_on_epoch}: DIVERGING "
+                f"(ratio={diverge_ratio:.3f}, {epochs_diverging}/{total_diverge_epochs} epochs)"
+            )
+            return self.loss_fn(blended_logits, labels)
+        else:
+            # Normal behavior: use original loss function
+            return self.loss_fn(logits, labels)
+
+    @MemProfilerHooks.memprofilable
+    def training_step(self, batch: BatchEncoding, batch_idx: int) -> STEP_OUTPUT:
+        answer_logits, labels, _ = self.logits_and_labels(batch, batch_idx)
+        loss = self._compute_diverging_loss(answer_logits, labels)
+        self.log("train_loss", loss, sync_dist=True)
+        return loss
+
+    @MemProfilerHooks.memprofilable
+    def validation_step(self, batch: BatchEncoding, batch_idx: int, dataloader_idx: int = 0) -> Optional[STEP_OUTPUT]:
+        answer_logits, labels, orig_labels = self.logits_and_labels(batch, batch_idx)
+        val_loss = self._compute_diverging_loss(answer_logits, labels)
+        self.log("val_loss", val_loss, prog_bar=True, sync_dist=True)
+        self.collect_answers(answer_logits, orig_labels)
+
+
 class BaseTestModule(StateLogInspectMixin):
     def __init__(self, *args, req_grad_mask: Optional[Dict] = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.req_grad_mask = req_grad_mask or {}
         self.epoch_losses = {}
         self.sampled_fwd_inputs = None
-
-    def setup(self, *args, **kwargs) -> None:
-        super().setup(*args, **kwargs)
 
     # TODO: use mock TASK_NUM_LABELS here (not just in __init__) to rely on rteboolq example method here for testing
     def _before_it_cfg_init(self, it_cfg: ITConfig) -> ITConfig:
@@ -529,6 +597,12 @@ class BaseTestModule(StateLogInspectMixin):
 
 
 class TestITModule(BaseTestModule, RTEBoolqSteps, RTEBoolqModuleMixin): ...
+
+
+class DivergeTestITModule(DivergeOnEpochMixin, BaseTestModule, RTEBoolqSteps, RTEBoolqModuleMixin):
+    """Test module with diverging loss behavior for FTS multi-level schedule testing."""
+
+    pass
 
 
 class TestFTS(StateLogInspectMixin, FinetuningScheduler):

--- a/tests/modules.py
+++ b/tests/modules.py
@@ -446,39 +446,42 @@ class DivergeOnEpochMixin:
         return it_cfg
 
     def _compute_diverging_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        """Compute loss with gradual divergence based on current_epoch to max_epochs ratio.
+        """Compute loss with gradual divergence using additive penalty.
 
-        Blends real logits with fake (zeros) logits to cause increasing loss. The ratio increases from 0 at
-        diverge_on_epoch to 1 at max_epochs.
+        Adds a baseline-relative penalty that increases from 0.5x baseline at diverge_on_epoch to 2.0x baseline at
+        max_epochs. This ensures monotonic loss increase regardless of learning improvements from parameter thawing,
+        enabling reliable cross-architecture testing.
         """
+        base_loss = self.loss_fn(logits, labels)
+
         if (
             self.diverge_on_epoch is not None
             and hasattr(self, "current_epoch")
             and self.current_epoch >= self.diverge_on_epoch
         ):
-            # Calculate divergence ratio based on progress from diverge_on_epoch to max_epochs
+            # Store baseline loss at divergence start (first epoch where divergence activates)
+            if not hasattr(self, "_divergence_baseline"):
+                self._divergence_baseline = base_loss.detach().item()
+
+            # Calculate additive penalty based on progress from diverge_on_epoch to max_epochs
             max_epochs = self.trainer.max_epochs if hasattr(self, "trainer") else 5
-            # Add 1 to epochs_diverging so that at diverge_on_epoch we get ratio > 0
-            # Example: diverge_on_epoch=2, max_epochs=5
-            #   epoch 2: (2-2+1) / (5-2) = 1/3 = 0.333
-            #   epoch 3: (3-2+1) / (5-2) = 2/3 = 0.667
-            #   epoch 4: (4-2+1) / (5-2) = 3/3 = 1.0
             epochs_diverging = self.current_epoch - self.diverge_on_epoch + 1
             total_diverge_epochs = max(max_epochs - self.diverge_on_epoch, 1)
-            diverge_ratio = min(epochs_diverging / total_diverge_epochs, 1.0)
+            progress = min(epochs_diverging / total_diverge_epochs, 1.0)
 
-            # Blend real logits with zeros to cause gradual divergence
-            fake_logits = torch.zeros_like(logits)
-            blended_logits = (1 - diverge_ratio) * logits + diverge_ratio * fake_logits
+            # Add increasing penalty: starts at 0.5x baseline, grows to 2.0x baseline
+            penalty = self._divergence_baseline * (0.5 + 1.5 * progress)
+            diverged_loss = base_loss + penalty
 
             rank_zero_debug(
                 f"Epoch {self.current_epoch} >= {self.diverge_on_epoch}: DIVERGING "
-                f"(ratio={diverge_ratio:.3f}, {epochs_diverging}/{total_diverge_epochs} epochs)"
+                f"(penalty={penalty:.3f}, baseline={self._divergence_baseline:.3f}, "
+                f"base={base_loss.item():.3f}, total={diverged_loss.item():.3f}, progress={progress:.3f})"
             )
-            return self.loss_fn(blended_logits, labels)
+            return diverged_loss
         else:
             # Normal behavior: use original loss function
-            return self.loss_fn(logits, labels)
+            return base_loss
 
     @MemProfilerHooks.memprofilable
     def training_step(self, batch: BatchEncoding, batch_idx: int) -> STEP_OUTPUT:

--- a/tests/parity_acceptance/cfg_aliases.py
+++ b/tests/parity_acceptance/cfg_aliases.py
@@ -7,6 +7,7 @@ from interpretune.protocol import AutoStrEnum, Adapter
 from interpretune.extensions import MemProfilerCfg, MemProfilerSchedule
 from interpretune.config import (
     HFFromPretrainedConfig,
+    ITLensBridgeConfig,
     ITLensFromPretrainedNoProcessingConfig,
     ITLensFromPretrainedConfig,
 )
@@ -100,14 +101,22 @@ cust_no_sae_grad = {
 ##################################
 
 default_test_fts_kwargs = {"max_depth": -1}
-l_gpt2_explicit_sched = {"fts_schedule_key": ("l_gpt2", "basic_explicit")}
-l_tl_ht_gpt2_multiphase_sched = {"fts_schedule_key": ("l_tl_ht_gpt2", "multiphase_explicit")}
-l_tl_bridge_gpt2_multiphase_sched = {"fts_schedule_key": ("l_tl_bridge_gpt2", "multiphase_explicit")}
+# Schedule keys now refer to fixture config keys and transform names
+l_gpt2_explicit_sched = {"fts_schedule_key": ("l_gpt2_sched", "basic_explicit")}
+l_gpt2_multiphase_sched = {"fts_schedule_key": ("l_gpt2_sched", "multiphase_explicit")}
+l_tl_ht_gpt2_multiphase_sched = {"fts_schedule_key": ("l_tl_ht_gpt2_sched", "multiphase_explicit")}
+l_tl_bridge_gpt2_multiphase_sched = {"fts_schedule_key": ("l_tl_bridge_gpt2_sched", "multiphase_explicit")}
+l_tl_bridge_gpt2_tl_names_multiphase_sched = {
+    "fts_schedule_key": ("l_tl_bridge_gpt2_tl_names_sched", "multiphase_explicit_tl_names")
+}
 l_ctx = {"adapter_ctx": (Adapter.lightning,)}
 l_gpt2_fts = {
     "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},
-    **l_gpt2_explicit_sched,
+    **l_gpt2_multiphase_sched,
     **l_ctx,
+    "module_cls": "tests.modules.DivergeTestITModule",
+    "model_cfg": {"diverge_on_epoch": 2},
+    "max_epochs": 5,
 }
 l_tl_ht_gpt2_fts_multiphase = {
     "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},
@@ -122,8 +131,11 @@ l_tl_ht_gpt2_fts_multiphase = {
 l_tl_bridge_gpt2_fts_multiphase = {
     "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},
     **l_tl_bridge_gpt2_multiphase_sched,
-    "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
-        model_name="gpt2-small", default_padding_side="left", use_bridge=True
+    "tl_cfg": ITLensBridgeConfig(
+        model_name="gpt2-small",
+        default_padding_side="left",
+        enable_compatibility_mode=True,
+        enable_compatibility_mode_kwargs={"no_processing": True},
     ),
     "module_cls": "tests.modules.DivergeTestITModule",
     "model_cfg": {"diverge_on_epoch": 2},
@@ -139,6 +151,23 @@ tl_bridge_custom_adapter_map = {
 }
 tl_bridge_fts_kwargs = {**default_test_fts_kwargs, "custom_strategy_adapters": tl_bridge_custom_adapter_map}
 get_nested(l_tl_bridge_gpt2_fts_multiphase, "callback_cfgs")[TestFTS] = {**tl_bridge_fts_kwargs}
+
+# TL-style naming variant: uses clean TL parameter names in schedules
+l_tl_bridge_gpt2_tl_names_fts = {
+    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},
+    **l_tl_bridge_gpt2_tl_names_multiphase_sched,
+    "tl_cfg": ITLensBridgeConfig(model_name="gpt2-small", default_padding_side="left"),
+    "module_cls": "tests.modules.DivergeTestITModule",
+    "model_cfg": {"diverge_on_epoch": 2},
+    "logging_level": "DEBUG",
+    "max_epochs": 5,
+}
+tl_bridge_fts_tl_names_kwargs = {
+    **default_test_fts_kwargs,
+    "custom_strategy_adapters": tl_bridge_custom_adapter_map,
+    "strategy_adapter_cfg": {"use_tl_names": True},
+}
+get_nested(l_tl_bridge_gpt2_tl_names_fts, "callback_cfgs")[TestFTS] = {**tl_bridge_fts_tl_names_kwargs}
 
 ########################################################################################################################
 # Composable CLI config aliases

--- a/tests/parity_acceptance/cfg_aliases.py
+++ b/tests/parity_acceptance/cfg_aliases.py
@@ -100,51 +100,35 @@ cust_no_sae_grad = {
 ##################################
 
 default_test_fts_kwargs = {"max_depth": -1}
-no_restore_fts_kwargs = {"max_depth": -1, "restore_best": False}
 l_gpt2_explicit_sched = {"fts_schedule_key": ("l_gpt2", "basic_explicit")}
-l_tl_gpt2_explicit_sched = {"fts_schedule_key": ("l_tl_gpt2", "basic_explicit")}
-l_tl_bridge_gpt2_explicit_sched = {"fts_schedule_key": ("l_tl_bridge_gpt2", "basic_explicit")}
+l_tl_ht_gpt2_multiphase_sched = {"fts_schedule_key": ("l_tl_ht_gpt2", "multiphase_explicit")}
+l_tl_bridge_gpt2_multiphase_sched = {"fts_schedule_key": ("l_tl_bridge_gpt2", "multiphase_explicit")}
 l_ctx = {"adapter_ctx": (Adapter.lightning,)}
-
 l_gpt2_fts = {
-    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},  # Create new dict copy
+    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},
     **l_gpt2_explicit_sched,
     **l_ctx,
 }
-# Use HookedTransformer (use_bridge=False) for FTS tests to avoid TransformerBridge checkpoint state_dict mismatches
-l_tl_gpt2_fts = {
-    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},  # Create new dict copy
-    **l_tl_gpt2_explicit_sched,
+l_tl_ht_gpt2_fts_multiphase = {
+    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},
+    **l_tl_ht_gpt2_multiphase_sched,
     "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
         model_name="gpt2-small", default_padding_side="left", use_bridge=False
     ),
+    "module_cls": "tests.modules.DivergeTestITModule",
+    "model_cfg": {"diverge_on_epoch": 2},
+    "max_epochs": 5,
 }
-# HookedTransformer test with restore_best=False
-l_tl_gpt2_fts_no_restore = {
-    "callback_cfgs": {TestFTS: {**no_restore_fts_kwargs}},  # Create new dict copy
-    **l_tl_gpt2_explicit_sched,
-    "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
-        model_name="gpt2-small", default_padding_side="left", use_bridge=False
-    ),
-}
-# TransformerBridge test with restore_best=False (for checkpoint format investigation)
-l_tl_bridge_gpt2_fts = {
-    "callback_cfgs": {TestFTS: {**no_restore_fts_kwargs}},  # Create new dict copy
-    **l_tl_bridge_gpt2_explicit_sched,
+l_tl_bridge_gpt2_fts_multiphase = {
+    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},
+    **l_tl_bridge_gpt2_multiphase_sched,
     "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
         model_name="gpt2-small", default_padding_side="left", use_bridge=True
     ),
-    "logging_level": "DEBUG",  # Enable DEBUG logging for checkpoint format investigation
-}
-
-# TransformerBridge test WITH restore_best=True (default_fts_cfg) - for checkpoint format investigation
-l_tl_bridge_gpt2_fts_restore = {
-    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},  # Create new dict copy
-    **l_tl_bridge_gpt2_explicit_sched,
-    "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
-        model_name="gpt2-small", default_padding_side="left", use_bridge=True
-    ),
-    "logging_level": "DEBUG",  # Enable DEBUG logging for checkpoint format investigation
+    "module_cls": "tests.modules.DivergeTestITModule",
+    "model_cfg": {"diverge_on_epoch": 2},
+    "logging_level": "DEBUG",
+    "max_epochs": 5,
 }
 
 # When running TransformerBridge based configs with FTS, favor a strategy adapter that can translate HF
@@ -153,14 +137,8 @@ tl_bridge_custom_adapter_map = {
     "single_device": "interpretune.adapters.transformer_lens.TransformerBridgeStrategyAdapter",
     "auto": "interpretune.adapters.transformer_lens.TransformerBridgeStrategyAdapter",
 }
-
-# Attach to both the restore and no-restore Bridge configs (safe identity mapping in stub)
 tl_bridge_fts_kwargs = {**default_test_fts_kwargs, "custom_strategy_adapters": tl_bridge_custom_adapter_map}
-get_nested(l_tl_bridge_gpt2_fts, "callback_cfgs")[TestFTS] = tl_bridge_fts_kwargs
-get_nested(l_tl_bridge_gpt2_fts_restore, "callback_cfgs")[TestFTS] = {
-    **tl_bridge_fts_kwargs
-}  # Separate copy for restore config
-
+get_nested(l_tl_bridge_gpt2_fts_multiphase, "callback_cfgs")[TestFTS] = {**tl_bridge_fts_kwargs}
 
 ########################################################################################################################
 # Composable CLI config aliases

--- a/tests/parity_acceptance/cfg_aliases.py
+++ b/tests/parity_acceptance/cfg_aliases.py
@@ -105,12 +105,15 @@ l_gpt2_explicit_sched = {"fts_schedule_key": ("l_gpt2", "basic_explicit")}
 l_tl_gpt2_explicit_sched = {"fts_schedule_key": ("l_tl_gpt2", "basic_explicit")}
 l_tl_bridge_gpt2_explicit_sched = {"fts_schedule_key": ("l_tl_bridge_gpt2", "basic_explicit")}
 l_ctx = {"adapter_ctx": (Adapter.lightning,)}
-default_fts_cfg = {"callback_cfgs": {TestFTS: default_test_fts_kwargs}}
-no_restore_fts_cfg = {"callback_cfgs": {TestFTS: no_restore_fts_kwargs}}
-l_gpt2_fts = {**default_fts_cfg, **l_gpt2_explicit_sched, **l_ctx}
+
+l_gpt2_fts = {
+    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},  # Create new dict copy
+    **l_gpt2_explicit_sched,
+    **l_ctx,
+}
 # Use HookedTransformer (use_bridge=False) for FTS tests to avoid TransformerBridge checkpoint state_dict mismatches
 l_tl_gpt2_fts = {
-    **default_fts_cfg,
+    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},  # Create new dict copy
     **l_tl_gpt2_explicit_sched,
     "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
         model_name="gpt2-small", default_padding_side="left", use_bridge=False
@@ -118,20 +121,45 @@ l_tl_gpt2_fts = {
 }
 # HookedTransformer test with restore_best=False
 l_tl_gpt2_fts_no_restore = {
-    **no_restore_fts_cfg,
+    "callback_cfgs": {TestFTS: {**no_restore_fts_kwargs}},  # Create new dict copy
     **l_tl_gpt2_explicit_sched,
     "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
         model_name="gpt2-small", default_padding_side="left", use_bridge=False
     ),
 }
-# TransformerBridge test with restore_best=False (until FTS updated to support TransformerBridge ckpt restore)
+# TransformerBridge test with restore_best=False (for checkpoint format investigation)
 l_tl_bridge_gpt2_fts = {
-    **no_restore_fts_cfg,
+    "callback_cfgs": {TestFTS: {**no_restore_fts_kwargs}},  # Create new dict copy
     **l_tl_bridge_gpt2_explicit_sched,
     "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
         model_name="gpt2-small", default_padding_side="left", use_bridge=True
     ),
+    "logging_level": "DEBUG",  # Enable DEBUG logging for checkpoint format investigation
 }
+
+# TransformerBridge test WITH restore_best=True (default_fts_cfg) - for checkpoint format investigation
+l_tl_bridge_gpt2_fts_restore = {
+    "callback_cfgs": {TestFTS: {**default_test_fts_kwargs}},  # Create new dict copy
+    **l_tl_bridge_gpt2_explicit_sched,
+    "tl_cfg": ITLensFromPretrainedNoProcessingConfig(
+        model_name="gpt2-small", default_padding_side="left", use_bridge=True
+    ),
+    "logging_level": "DEBUG",  # Enable DEBUG logging for checkpoint format investigation
+}
+
+# When running TransformerBridge based configs with FTS, favor a strategy adapter that can translate HF
+# canonical names to runtime names; by default map a few common strategy keys for local/CI testing.
+tl_bridge_custom_adapter_map = {
+    "single_device": "interpretune.adapters.transformer_lens.TransformerBridgeStrategyAdapter",
+    "auto": "interpretune.adapters.transformer_lens.TransformerBridgeStrategyAdapter",
+}
+
+# Attach to both the restore and no-restore Bridge configs (safe identity mapping in stub)
+tl_bridge_fts_kwargs = {**default_test_fts_kwargs, "custom_strategy_adapters": tl_bridge_custom_adapter_map}
+get_nested(l_tl_bridge_gpt2_fts, "callback_cfgs")[TestFTS] = tl_bridge_fts_kwargs
+get_nested(l_tl_bridge_gpt2_fts_restore, "callback_cfgs")[TestFTS] = {
+    **tl_bridge_fts_kwargs
+}  # Separate copy for restore config
 
 
 ########################################################################################################################

--- a/tests/parity_acceptance/cfg_aliases.py
+++ b/tests/parity_acceptance/cfg_aliases.py
@@ -145,9 +145,10 @@ l_tl_bridge_gpt2_fts_multiphase = {
 
 # When running TransformerBridge based configs with FTS, favor a strategy adapter that can translate HF
 # canonical names to runtime names; by default map a few common strategy keys for local/CI testing.
+# Uses the plugin alias 'transformerbridge' registered via entry point in pyproject.toml
 tl_bridge_custom_adapter_map = {
-    "single_device": "interpretune.adapters.transformer_lens.TransformerBridgeStrategyAdapter",
-    "auto": "interpretune.adapters.transformer_lens.TransformerBridgeStrategyAdapter",
+    "single_device": "transformerbridge",
+    "auto": "transformerbridge",
 }
 tl_bridge_fts_kwargs = {**default_test_fts_kwargs, "custom_strategy_adapters": tl_bridge_custom_adapter_map}
 get_nested(l_tl_bridge_gpt2_fts_multiphase, "callback_cfgs")[TestFTS] = {**tl_bridge_fts_kwargs}

--- a/tests/parity_acceptance/expected.py
+++ b/tests/parity_acceptance/expected.py
@@ -104,11 +104,83 @@ sl_parity_results = {
     "train_cuda_32": TestResult(exact_results=def_results("cuda", 32)),
 }
 
-# Run tests with IT_GLOBAL_STATE_LOG_MODE=1 to populate these expected results
+# =====================================================================================
+# FinetuningScheduler (FTS) Expected Results
+# =====================================================================================
+#
+# These dictionaries validate checkpoint restoration and parameter thawing behavior
+# across different TransformerLens architectures and naming conventions.
+#
+# RUNNING TESTS TO CAPTURE STATE:
+# Run tests with IT_GLOBAL_STATE_LOG_MODE=1 to populate/update these expected results:
+#   IT_GLOBAL_STATE_LOG_MODE=1 python -m pytest \
+#     tests/parity_acceptance/test_it_fts.py::test_parity_fts[train_cpu_32_l_fts] -v
+#
+# PARAMETER COUNTS PER PHASE:
+#
+# Base GPT-2 (3-phase schedule):
+#   Phase 0: 36 params  (blocks 9-11, 3 blocks × (4 attn + 4 mlp + 4 ln params per block))
+#   Phase 1: 60 params  (adds blocks 7-8, +24 params)
+#   Phase 2: 148 params (adds blocks 0-6 + embeddings, +88 params)
+#
+# HookedTransformer (3-phase schedule):
+#   Phase 0: 48 params  (blocks 9-11, 3 blocks × (8 attn + 4 mlp + 4 ln params per block))
+#   NOTE: +4 params per block vs Base GPT-2 due to split QKV projections (-2 qkv joint, +6 q/k/v split)
+#   Phase 1: 80 params  (adds blocks 7-8, +32 params)
+#   Phase 2: 196 params (adds blocks 0-6 + embeddings, +116 params)
+#
+# TransformerBridge Canonical (3-phase schedule):
+#   Phase 0: 54 params  (blocks 9-11, 3 blocks × (10 attn + 4 mlp + 4 ln params per block))
+#   NOTE: +2 params per block vs HookedTransformer due to thawed (but unused) joint QKV projections
+#   Phase 1: 90 params  (adds blocks 7-8, +36 params)
+#   Phase 2: 219 params (adds blocks 0-6 + embeddings, +129 params)
+#
+# TransformerBridge TL Names (3-phase schedule):
+#   Phase 0: 48 params  (blocks 9-11, identical to HookedTransformer)
+#   Phase 1: 80 params  (adds blocks 7-8, identical to HookedTransformer)
+#   Phase 2: 197 params (adds blocks 0-6 + 2 ln_final - 1 unembed weight, +1 vs HookedTransformer)
+#   NOTE: TL names mode bidirectionally translates canonical<->TL names using TL names for schedule generation and
+#         orchestration. The 2 ln_final parameters are thawed because we left implicit_ln_thaw `True` and
+#         we did not configure enable_compatibility_mode so the unembed weight remained tied to embed weight and
+#         thus we have only an unembed bias.
+#         +2 thawed ln_final params - 1 unembed weight param = net +1 param vs HookedTransformer
+#
+# WHY THE DIFFERENCES?
+#
+# Base vs HookedTransformer (+12 params in Phase 0):
+#   - HookedTransformer has 8 attention params per block vs Base's 4
+#   - Base: c_attn.weight, c_attn.bias, c_proj.weight, c_proj.bias (4 params)
+#   - HookedTransformer: W_Q, W_K, W_V, W_O, b_Q, b_K, b_V, b_O (8 params)
+#   - Split Q/K/V projections vs joint QKV (-2 qkv joint, +6 q/k/v split = net +4 per block)
+#   - LayerNorm params: explicitly included in HookedTransformer schedules, explicitly included in Base schedules
+#
+# TransformerBridge Canonical vs HookedTransformer (+6 params in Phase 0):
+#   - Bridge stores joint QKV projection (qkv.weight, qkv.bias per block)
+#   - Split Q, K, V parameters are materialized as new parameters for LinearBridge modules
+#   - Joint and split QKV parameters do NOT share underlying storage
+#   - Result: 2 additional params per attention layer × 3 blocks = +6 params
+#
+# TransformerBridge TL Names vs HookedTransformer (parameter differences):
+#   - TL names mode transforms canonical parameter names to TL-style names
+#   - LayerNorms handled differently: explicit in HookedTransformer schedules, implicit_ln_thaw in Bridge
+#   - Unembed parameters may differ (weight tying depends on enable_compatibility_mode)
+#   - Using TL names provides standard interface for cross-architecture schedules
+#   - CanonicalModelView (use_tl_names=False, default) allows direct canonical specification
+#     but may expose architectural differences reducing schedule portability
+#
+# CHECKPOINT RESTORATION (with additive penalty divergence):
+#   - Divergence starts at epoch 2 (first epoch of phase 1)
+#   - Best checkpoint remains at depth 0 (phase 0) for all architectures
+#   - All tests correctly restore to best checkpoint from phase 0 in epochs 3-4
+#
+# See docs/fts_transformerlens_integration.md for detailed documentation
+# =====================================================================================
+
+# Base GPT-2 FTS Results (3-phase schedule: 36 → 60 → 148 params)
 l_fts_callback_results = {
     0: {
         "curr_depth": 0,
-        "depth_remaining": 1,
+        "depth_remaining": 2,
         "ft_epoch": 0,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
@@ -120,7 +192,7 @@ l_fts_callback_results = {
     },
     1: {
         "curr_depth": 0,
-        "depth_remaining": 1,
+        "depth_remaining": 2,
         "ft_epoch": 1,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
@@ -132,31 +204,44 @@ l_fts_callback_results = {
     },
     2: {
         "curr_depth": 1,
-        "depth_remaining": 0,
+        "depth_remaining": 1,
         "ft_epoch": 2,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 148,
+        "curr_thawed_params": 60,
         "optim_pg_len": 2,
         "ckpt_cback_current_ckpt_depth": 0,
         "ckpt_cback_best_ckpt_depth": 0,
     },
     3: {
-        "curr_depth": 1,
+        "curr_depth": 2,
         "depth_remaining": 0,
         "ft_epoch": 3,
-        "current_ckpt_depth": 1,
-        "best_ckpt_depth": 1,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
         "curr_thawed_params": 148,
-        "optim_pg_len": 2,
-        "ckpt_cback_current_ckpt_depth": 1,
-        "ckpt_cback_best_ckpt_depth": 1,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+    4: {
+        "curr_depth": 2,
+        "depth_remaining": 0,
+        "ft_epoch": 4,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 1,
+        "curr_thawed_params": 148,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
     },
 }
 
-# HookedTransformer with multi-level explicit schedule (3 phases)
+# HookedTransformer FTS Results (3-phase schedule: 48 → 80 → 196 params)
+# TL-style naming with implicit LayerNorm thawing via regex wildcards
 l_tl_ht_fts_multiphase_callback_results = {
     0: {
         "curr_depth": 0,
@@ -220,7 +305,9 @@ l_tl_ht_fts_multiphase_callback_results = {
     },
 }
 
-# TransformerBridge with multi-level explicit schedule (3 phases)
+# TransformerBridge Canonical FTS Results (3-phase schedule: 54 → 90 → 219 params)
+# Canonical HF naming with _original_component wrappers, +2 params/block vs HookedTransformer due to
+# joint QKV projections
 l_tl_bridge_fts_multiphase_callback_results = {
     0: {
         "curr_depth": 0,
@@ -265,7 +352,7 @@ l_tl_bridge_fts_multiphase_callback_results = {
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 218,
+        "curr_thawed_params": 219,
         "optim_pg_len": 3,
         "ckpt_cback_current_ckpt_depth": 0,
         "ckpt_cback_best_ckpt_depth": 0,
@@ -277,7 +364,73 @@ l_tl_bridge_fts_multiphase_callback_results = {
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 218,
+        "curr_thawed_params": 219,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+}
+
+# TransformerBridge TL Names FTS Results (3-phase schedule: 48 → 80 → 197 params)
+# TL-style naming mode (blocks.9.attn.W_Q) with 1:1 mapping to canonical params
+# Joint QKV params excluded from TL name mapping, implicitly thawed via regex wildcard patterns
+l_tl_bridge_fts_tl_names_multiphase_callback_results = {
+    0: {
+        "curr_depth": 0,
+        "depth_remaining": 2,
+        "ft_epoch": 0,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 0,
+        "curr_thawed_params": 48,
+        "optim_pg_len": 1,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+    1: {
+        "curr_depth": 0,
+        "depth_remaining": 2,
+        "ft_epoch": 1,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 1,
+        "curr_thawed_params": 48,
+        "optim_pg_len": 1,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+    2: {
+        "curr_depth": 1,
+        "depth_remaining": 1,
+        "ft_epoch": 2,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 1,
+        "curr_thawed_params": 80,
+        "optim_pg_len": 2,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+    3: {
+        "curr_depth": 2,
+        "depth_remaining": 0,
+        "ft_epoch": 3,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 1,
+        "curr_thawed_params": 197,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+    4: {
+        "curr_depth": 2,
+        "depth_remaining": 0,
+        "ft_epoch": 4,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 1,
+        "curr_thawed_params": 197,
         "optim_pg_len": 3,
         "ckpt_cback_current_ckpt_depth": 0,
         "ckpt_cback_best_ckpt_depth": 0,
@@ -306,5 +459,9 @@ fts_parity_results = {
     "train_cuda_32_l_tl_bridge_fts": TestResult(
         exact_results=def_results("cuda", 32, ds_cfg="train"),
         callback_results=l_tl_bridge_fts_multiphase_callback_results,
+    ),
+    "train_cuda_32_l_tl_bridge_tl_names_fts": TestResult(
+        exact_results=def_results("cuda", 32, ds_cfg="train"),
+        callback_results=l_tl_bridge_fts_tl_names_multiphase_callback_results,
     ),
 }

--- a/tests/parity_acceptance/expected.py
+++ b/tests/parity_acceptance/expected.py
@@ -104,6 +104,7 @@ sl_parity_results = {
     "train_cuda_32": TestResult(exact_results=def_results("cuda", 32)),
 }
 
+# Run tests with IT_GLOBAL_STATE_LOG_MODE=1 to populate these expected results
 l_fts_callback_results = {
     0: {
         "curr_depth": 0,
@@ -155,11 +156,11 @@ l_fts_callback_results = {
     },
 }
 
-# TODO: this will need to be edited when testing FTS with TransformerBridge mode in the future
-l_tl_fts_callback_results = {
+# HookedTransformer with multi-level explicit schedule (3 phases)
+l_tl_ht_fts_multiphase_callback_results = {
     0: {
         "curr_depth": 0,
-        "depth_remaining": 1,
+        "depth_remaining": 2,
         "ft_epoch": 0,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
@@ -171,7 +172,7 @@ l_tl_fts_callback_results = {
     },
     1: {
         "curr_depth": 0,
-        "depth_remaining": 1,
+        "depth_remaining": 2,
         "ft_epoch": 1,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
@@ -183,88 +184,47 @@ l_tl_fts_callback_results = {
     },
     2: {
         "curr_depth": 1,
-        "depth_remaining": 0,
+        "depth_remaining": 1,
         "ft_epoch": 2,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 196,
+        "curr_thawed_params": 80,
         "optim_pg_len": 2,
         "ckpt_cback_current_ckpt_depth": 0,
         "ckpt_cback_best_ckpt_depth": 0,
     },
     3: {
-        "curr_depth": 1,
+        "curr_depth": 2,
         "depth_remaining": 0,
         "ft_epoch": 3,
-        "current_ckpt_depth": 1,
-        "best_ckpt_depth": 1,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
         "curr_thawed_params": 196,
-        "optim_pg_len": 2,
-        "ckpt_cback_current_ckpt_depth": 1,
-        "ckpt_cback_best_ckpt_depth": 1,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+    4: {
+        "curr_depth": 2,
+        "depth_remaining": 0,
+        "ft_epoch": 4,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 1,
+        "curr_thawed_params": 196,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
     },
 }
 
-# TODO: Run tests with IT_GLOBAL_STATE_LOG_MODE=1 to populate these expected results
-# HookedTransformer with restore_best=False - expected to have different best_ckpt_depth values
-l_tl_fts_no_restore_callback_results = {
+# TransformerBridge with multi-level explicit schedule (3 phases)
+l_tl_bridge_fts_multiphase_callback_results = {
     0: {
         "curr_depth": 0,
-        "depth_remaining": 1,
-        "ft_epoch": 0,
-        "current_ckpt_depth": 0,
-        "best_ckpt_depth": 0,
-        "best_ckpt_pgs_len": 0,
-        "curr_thawed_params": 48,
-        "optim_pg_len": 1,
-        "ckpt_cback_current_ckpt_depth": 0,
-        "ckpt_cback_best_ckpt_depth": 0,
-    },
-    1: {
-        "curr_depth": 0,
-        "depth_remaining": 1,
-        "ft_epoch": 1,
-        "current_ckpt_depth": 0,
-        "best_ckpt_depth": 0,
-        "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 48,
-        "optim_pg_len": 1,
-        "ckpt_cback_current_ckpt_depth": 0,
-        "ckpt_cback_best_ckpt_depth": 0,
-    },
-    2: {
-        "curr_depth": 1,
-        "depth_remaining": 0,
-        "ft_epoch": 2,
-        "current_ckpt_depth": 0,
-        "best_ckpt_depth": 0,
-        "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 196,
-        "optim_pg_len": 2,
-        "ckpt_cback_current_ckpt_depth": 0,
-        "ckpt_cback_best_ckpt_depth": 0,
-    },
-    3: {
-        "curr_depth": 1,
-        "depth_remaining": 0,
-        "ft_epoch": 3,
-        "current_ckpt_depth": 1,
-        "best_ckpt_depth": 1,
-        "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 196,
-        "optim_pg_len": 2,
-        "ckpt_cback_current_ckpt_depth": 1,
-        "ckpt_cback_best_ckpt_depth": 1,
-    },
-}
-
-# TransformerBridge with restore_best=False - expected to have same structure but different param counts
-l_tl_bridge_fts_callback_results = {
-    0: {
-        "curr_depth": 0,
-        "depth_remaining": 1,
+        "depth_remaining": 2,
         "ft_epoch": 0,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
@@ -276,7 +236,7 @@ l_tl_bridge_fts_callback_results = {
     },
     1: {
         "curr_depth": 0,
-        "depth_remaining": 1,
+        "depth_remaining": 2,
         "ft_epoch": 1,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
@@ -288,29 +248,42 @@ l_tl_bridge_fts_callback_results = {
     },
     2: {
         "curr_depth": 1,
-        "depth_remaining": 0,
+        "depth_remaining": 1,
         "ft_epoch": 2,
         "current_ckpt_depth": 0,
         "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
-        "curr_thawed_params": 218,
+        "curr_thawed_params": 90,
         "optim_pg_len": 2,
         "ckpt_cback_current_ckpt_depth": 0,
         "ckpt_cback_best_ckpt_depth": 0,
     },
     3: {
-        "curr_depth": 1,
+        "curr_depth": 2,
         "depth_remaining": 0,
         "ft_epoch": 3,
-        "current_ckpt_depth": 1,
-        "best_ckpt_depth": 1,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
         "best_ckpt_pgs_len": 1,
         "curr_thawed_params": 218,
-        "optim_pg_len": 2,
-        "ckpt_cback_current_ckpt_depth": 1,
-        "ckpt_cback_best_ckpt_depth": 1,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
+    },
+    4: {
+        "curr_depth": 2,
+        "depth_remaining": 0,
+        "ft_epoch": 4,
+        "current_ckpt_depth": 0,
+        "best_ckpt_depth": 0,
+        "best_ckpt_pgs_len": 1,
+        "curr_thawed_params": 218,
+        "optim_pg_len": 3,
+        "ckpt_cback_current_ckpt_depth": 0,
+        "ckpt_cback_best_ckpt_depth": 0,
     },
 }
+
 
 # TODO: using result dicts in this module for now but ultimately plan to save/construct TestResults from a yaml file
 # here to make programmatic management of expected results easier
@@ -321,22 +294,17 @@ fts_parity_results = {
     "train_cpu_32_l_fts": TestResult(
         exact_results=def_results("cpu", 32, ds_cfg="train"), callback_results=l_fts_callback_results
     ),
-    "train_cpu_32_l_tl_fts": TestResult(
-        exact_results=def_results("cpu", 32, ds_cfg="train"), callback_results=l_tl_fts_callback_results
-    ),
     "train_cuda_32_l_fts": TestResult(
         exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_fts_callback_results
     ),
-    "train_cuda_32_l_tl_fts": TestResult(
-        exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_tl_fts_callback_results
+    "train_cpu_32_l_tl_ht_fts": TestResult(
+        exact_results=def_results("cpu", 32, ds_cfg="train"), callback_results=l_tl_ht_fts_multiphase_callback_results
     ),
-    "train_cuda_32_l_tl_fts_no_restore": TestResult(
-        exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_tl_fts_no_restore_callback_results
+    "train_cuda_32_l_tl_ht_fts": TestResult(
+        exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_tl_ht_fts_multiphase_callback_results
     ),
     "train_cuda_32_l_tl_bridge_fts": TestResult(
-        exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_tl_bridge_fts_callback_results
-    ),
-    "train_cuda_32_l_tl_bridge_fts_restore": TestResult(
-        exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_tl_bridge_fts_callback_results
+        exact_results=def_results("cuda", 32, ds_cfg="train"),
+        callback_results=l_tl_bridge_fts_multiphase_callback_results,
     ),
 }

--- a/tests/parity_acceptance/expected.py
+++ b/tests/parity_acceptance/expected.py
@@ -336,4 +336,7 @@ fts_parity_results = {
     "train_cuda_32_l_tl_bridge_fts": TestResult(
         exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_tl_bridge_fts_callback_results
     ),
+    "train_cuda_32_l_tl_bridge_fts_restore": TestResult(
+        exact_results=def_results("cuda", 32, ds_cfg="train"), callback_results=l_tl_bridge_fts_callback_results
+    ),
 }

--- a/tests/parity_acceptance/test_it_fts.py
+++ b/tests/parity_acceptance/test_it_fts.py
@@ -27,6 +27,7 @@ from tests.parity_acceptance.cfg_aliases import (
     l_tl_gpt2_fts,
     l_tl_gpt2_fts_no_restore,
     l_tl_bridge_gpt2_fts,
+    l_tl_bridge_gpt2_fts_restore,
     TestFTS,
 )
 from tests.parity_acceptance.expected import fts_parity_results
@@ -70,6 +71,11 @@ PARITY_FTS_CONFIGS = (
     ),
     FTSParityTest(
         alias="train_cuda_32_l_tl_bridge_fts", cfg=FTSParityCfg(**l_tl_bridge_gpt2_fts, **cuda), marks="cuda_l_optional"
+    ),
+    FTSParityTest(
+        alias="train_cuda_32_l_tl_bridge_fts_restore",
+        cfg=FTSParityCfg(**l_tl_bridge_gpt2_fts_restore, **cuda),
+        marks="cuda_l_optional",
     ),
 )
 

--- a/tests/parity_acceptance/test_it_fts.py
+++ b/tests/parity_acceptance/test_it_fts.py
@@ -24,10 +24,8 @@ from tests.orchestration import parity_test
 from tests.parity_acceptance.cfg_aliases import (
     cuda,
     l_gpt2_fts,
-    l_tl_gpt2_fts,
-    l_tl_gpt2_fts_no_restore,
-    l_tl_bridge_gpt2_fts,
-    l_tl_bridge_gpt2_fts_restore,
+    l_tl_ht_gpt2_fts_multiphase,
+    l_tl_bridge_gpt2_fts_multiphase,
     TestFTS,
 )
 from tests.parity_acceptance.expected import fts_parity_results
@@ -61,21 +59,17 @@ PARITY_FTS_CONFIGS = (
     # This test creates large checkpoint files and may cause out-of-space errors when run alongside other tests.
     # Consider switching to a trivial custom model if this becomes problematic.
     FTSParityTest(alias="train_cpu_32_l_fts", cfg=FTSParityCfg(**l_gpt2_fts), marks="standalone"),
-    FTSParityTest(alias="train_cpu_32_l_tl_fts", cfg=FTSParityCfg(**l_tl_gpt2_fts), marks="l_optional"),
     FTSParityTest(alias="train_cuda_32_l_fts", cfg=FTSParityCfg(**l_gpt2_fts, **cuda), marks="cuda_l_optional"),
-    FTSParityTest(alias="train_cuda_32_l_tl_fts", cfg=FTSParityCfg(**l_tl_gpt2_fts, **cuda), marks="cuda"),
     FTSParityTest(
-        alias="train_cuda_32_l_tl_fts_no_restore",
-        cfg=FTSParityCfg(**l_tl_gpt2_fts_no_restore, **cuda),
-        marks="cuda_l_optional",
+        alias="train_cpu_32_l_tl_ht_fts", cfg=FTSParityCfg(**l_tl_ht_gpt2_fts_multiphase), marks="l_optional"
     ),
     FTSParityTest(
-        alias="train_cuda_32_l_tl_bridge_fts", cfg=FTSParityCfg(**l_tl_bridge_gpt2_fts, **cuda), marks="cuda_l_optional"
+        alias="train_cuda_32_l_tl_ht_fts", cfg=FTSParityCfg(**l_tl_ht_gpt2_fts_multiphase, **cuda), marks="cuda_alone"
     ),
     FTSParityTest(
-        alias="train_cuda_32_l_tl_bridge_fts_restore",
-        cfg=FTSParityCfg(**l_tl_bridge_gpt2_fts_restore, **cuda),
-        marks="cuda_l_optional",
+        alias="train_cuda_32_l_tl_bridge_fts",
+        cfg=FTSParityCfg(**l_tl_bridge_gpt2_fts_multiphase, **cuda),
+        marks="cuda_alone",
     ),
 )
 

--- a/tests/parity_acceptance/test_it_fts.py
+++ b/tests/parity_acceptance/test_it_fts.py
@@ -26,6 +26,7 @@ from tests.parity_acceptance.cfg_aliases import (
     l_gpt2_fts,
     l_tl_ht_gpt2_fts_multiphase,
     l_tl_bridge_gpt2_fts_multiphase,
+    l_tl_bridge_gpt2_tl_names_fts,
     TestFTS,
 )
 from tests.parity_acceptance.expected import fts_parity_results
@@ -71,6 +72,11 @@ PARITY_FTS_CONFIGS = (
         cfg=FTSParityCfg(**l_tl_bridge_gpt2_fts_multiphase, **cuda),
         marks="cuda_alone",
     ),
+    FTSParityTest(
+        alias="train_cuda_32_l_tl_bridge_tl_names_fts",
+        cfg=FTSParityCfg(**l_tl_bridge_gpt2_tl_names_fts, **cuda),
+        marks="cuda_alone",
+    ),
 )
 
 EXPECTED_PARITY_FTS = {cfg.alias: cfg.expected for cfg in PARITY_FTS_CONFIGS}
@@ -79,14 +85,17 @@ EXPECTED_PARITY_FTS = {cfg.alias: cfg.expected for cfg in PARITY_FTS_CONFIGS}
 @pytest.mark.usefixtures("make_deterministic")
 @RunIf(lightning=True, finetuning_scheduler=True)
 @pytest.mark.parametrize(("test_alias", "test_cfg"), pytest_factory(PARITY_FTS_CONFIGS, unpack=False))
-def test_parity_fts(gpt2_ft_schedules, recwarn, tmp_path, test_alias, test_cfg):
+def test_parity_fts(recwarn, tmp_path, test_alias, test_cfg, request):
     state_log_mode = IT_GLOBAL_STATE_LOG_MODE  # one can manually set this to True for a local test override
     expected_results = EXPECTED_PARITY_FTS[test_alias] or {}
     expected_warnings = TL_LIGHTNING_CTX_WARNS if Adapter.lightning in test_cfg.adapter_ctx else TL_CTX_WARNS
     expected_warnings = copy(expected_warnings) + FTS_CTX_WARNS
     if test_cfg.fts_schedule_key:
-        mod, type = test_cfg.fts_schedule_key
-        test_cfg.callback_cfgs[TestFTS]["ft_schedule"] = gpt2_ft_schedules[mod][type]
+        fixture_key, schedule_type = test_cfg.fts_schedule_key
+        # Request the fixture dynamically using the fixture_key from schedule config
+        fixture_name = f"get_ft_schedule__{fixture_key}__setup"
+        schedules = request.getfixturevalue(fixture_name)
+        test_cfg.callback_cfgs[TestFTS]["ft_schedule"] = schedules[schedule_type]
         test_cfg.callback_cfgs[TestFTS]["expected_exact"] = expected_results.pop("callback_results", {})
         test_cfg.callback_cfgs[TestFTS]["state_log_dir"] = tmp_path if state_log_mode else None
         test_cfg.callback_cfgs[TestFTS]["test_alias"] = test_alias

--- a/tests/runif.py
+++ b/tests/runif.py
@@ -64,6 +64,7 @@ RUNIF_ALIASES = {
     "standalone": standalone_mark,
     "l_fts": {**lightning_mark, **fts_mark},
     "cuda": cuda_mark,
+    "cuda_alone": {**cuda_mark, **standalone_mark},
     "cuda_prof": {**cuda_mark, **profiling_mark},
     "cuda_profci": {**cuda_mark, **profiling_ci_mark},
     "cuda_l": {**cuda_mark, **lightning_mark},

--- a/tests/warns.py
+++ b/tests/warns.py
@@ -65,6 +65,8 @@ SL_CTX_WARNS = SL_EXPECTED_WARNS + CORE_CTX_WARNS
 SL_LIGHTNING_CTX_WARNS = SL_CTX_WARNS + LIGHTING_CTX_WARNS
 
 FTS_CTX_WARNS = [
+    "You defined a `validation_step`",
+    "`max_epochs` was not",
     ".*currently depends upon.*",
     "No monitor metric specified for.*",
     "Pruning explicitly specified shared parameter.*",


### PR DESCRIPTION
## Overview

This PR adds comprehensive support for using FinetuningScheduler (FTS) with TransformerLens v3 TransformerBridge models. It introduces a ModelView abstraction and a plugin-based StrategyAdapter that let FTS operate using either canonical HuggingFace names or TransformerLens (TL) style names, with robust schedule generation and checkpoint restoration across multi-phase fine-tuning schedules.

## Key Features

### 1. **FTS Plugin Entry Point Registration**
- Registered `TransformerBridgeStrategyAdapter` as an FTS plugin via entry point: `finetuning_scheduler.strategy_adapters.transformerbridge`
- Allows discovery and usage via the short alias (`transformerbridge`) or full class path
- Adapter supports both **canonical** and **TL-style** naming modes (toggle via `strategy_adapter_cfg`)

### 2. **ModelView Abstraction Layer**
- Added `ModelView` abstraction (`src/interpretune/adapters/model_view.py`) for flexible name translation between naming conventions
- Implemented `TLNamesModelView` to provide bidirectional TransformerLens ↔ canonical mappings and to support schedule→optimizer translations
- Supports implicit LayerNorm thawing (`implicit_ln_thaw`) and component tracing to match parameters by identity

### 3. **TransformerBridge Strategy Adapter**
- Enhanced `TransformerBridgeStrategyAdapter` in `src/interpretune/adapters/transformer_lens.py`
- Implements checkpoint restoration for TransformerBridge with proper key expansion:
  - Prefixed HF keys (`model.original_model.*`)
  - TransformerLens TL-style aliases (`model.blocks.*`, `model.embed`, `model.unembed`, etc.)
- Bridge-aware state_dict/load helpers to avoid duplicate keys

### 4. **Checkpoint Restoration Improvements**
- Added `before_restore_model()` hook for expanding HF-format checkpoint keys
- Preserves non-model keys (optimizers, metadata) during restoration
- Implements `DivergeOnEpoch` functionality for multi-phase testing
- Support for restoring across multiple FTS phases

### 5. **Logging and Debugging Infrastructure**
- Added configurable logging level support via `LoggingConf.logging_level`
- Consolidated setup lifecycle with stream/file logging handlers
- Added experiment-id initialization (`_make_setup_dirs` / `_make_init_dirs`)
- Enhanced debug inspection utilities for state_dict analysis

## Documentation

### New Documentation Files
- **`docs/fts_transformerlens_integration.md`** (374 lines): Comprehensive guide on FTS + TransformerLens integration, plugin usage patterns, and configuration examples
- **`docs/tl_style_naming_implementation.md`** (287 lines): Detailed documentation on TL-style naming, schedule generation, LayerNorm behavior, and mapping caveats

### Updated Documentation
- **Copilot instructions** (`...github/copilot-instructions.md`): Added FTS plugin configuration hierarchy and usage patterns
- **README.md**: Updated package description

## Testing

### New Tests
- `test_transformerbridge_adapter_basic_properties`: Sanity tests for adapter implementation
- Parity test variant: `train_cuda_32_l_tl_bridge_fts_restore` with expected results
- Multi-phase FTS schedule tests with checkpoint restoration
- Updated fixtures and test configurations for custom ModelView usage

### Test Improvements
- Fixed test configuration mutation bug (shallow copy issue in `cfg_aliases.py`)
- Updated Base GPT-2 schedule to 3-phase for parity with TL/Bridge tests
- Regenerated expected state from `dev_state_log.yaml`
- All FTS parity and core TL tests pass

## Files Changed (29 files, +3480/-207 lines)

### Core Implementation
- `src/interpretune/adapters/model_view.py` (new, 182 lines)
- `src/interpretune/adapters/transformer_lens.py` (+712 lines)
- `src/interpretune/base/components/core.py` (+117 lines)
- `src/interpretune/config/transformer_lens.py` (+108 lines)

### Configuration & Entry Points
- `pyproject.toml`: FTS plugin entry point registration
- `src/it_examples/example_module_registry.yaml` (new, 140 lines)

### Tests
- `tests/core/test_transformer_lens.py` (+816 lines)
- `tests/parity_acceptance/test_it_fts.py`: Added restore variants
- `tests/parity_acceptance/expected.py`: Updated expected results
- `tests/conftest.py`: Enhanced fixtures for ModelView support

### Documentation
- `docs/fts_transformerlens_integration.md` (new, 374 lines)
- `docs/tl_style_naming_implementation.md` (new, 287 lines)
- `.github/copilot-instructions.md` (+98 lines)

## Breaking Changes

None - this is a new feature addition with backward compatibility maintained.

## Dependencies

- Uses pending TransformerLens consolidated PR commit (updated in `requirements/ci/overrides.txt`)
- Requires FinetuningScheduler with plugin entry point support

## Related Issues

Addresses TransformerLens v3 TransformerBridge integration with FTS for flexible parameter-efficient fine-tuning workflows.
