### PR TITLE
Docs: tighten the framework description in index and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,24 @@
 
 ## What is interpretune?
 
-Interpretune is an AI world model analysis framework that enables a wide range of
-interpretability methods and packages to leverage **composable, shareable analysis operations and
-state**, accelerating collaborative world model analysis and tuning with PyTorch. It lets both
-humans and agents inspect and refine the mechanistic and causal faithfulness of model reasoning
-at mutually intelligible levels of abstraction.
+Interpretune is a (pre-MVP) AI world model analysis framework. It strives to provide composable, shareable latent-space analysis mutually intelligible to humans and agents.
 
-**What that unlocks**: transparent, causally faithful reasoning with greater confidence in
-conclusions; model self-reflection; inter-agent latent-space collaboration; and more
-sample-efficient, world-model-guided collaborative tuning.
+By granting a wide range of interpretability methods and packages access to **composable**, **shareable analysis operations** and **state** it accelerates novel, collaborative, world model analysis and tuning with PyTorch.
 
-Interpretune composes adapters at **multiple levels of abstraction** — the *framework* level
-(core PyTorch, [Lightning](https://github.com/Lightning-AI/pytorch-lightning)), the
-*interpretability latent-model* level ([TransformerLens](https://github.com/TransformerLensOrg/TransformerLens),
-[NNsight](https://github.com/ndif-team/nnsight)), and the *analysis* level
-([circuit-tracer](https://github.com/safety-research/circuit-tracer),
-[SAE-Lens](https://github.com/decoderesearch/SAELens)) — over a shared session/protocol layer.
+Both humans and agents can inspect and refine the mechanistic and causal faithfulness of model reasoning at mutually intelligible levels of abstraction. Core framework goals:
+
+- transparent, causally faithful reasoning
+- augmented model self-reflection
+- world-model-guided collaborative tuning
+
+Interpretune composes adapters at multiple levels of abstraction over a shared session/protocol layer:
+
+- the *framework* level (core PyTorch, [Lightning](https://github.com/Lightning-AI/pytorch-lightning))
+- the *interpretability latent-model* level ([TransformerLens](https://github.com/TransformerLensOrg/TransformerLens),
+[NNsight](https://github.com/ndif-team/nnsight))
+- the *analysis* level ([circuit-tracer](https://github.com/safety-research/circuit-tracer),
+[SAELens](https://github.com/decoderesearch/SAELens))
+
 This composition pattern is what lets researchers collaborate across interpretability frameworks:
 analysis operations (e.g. `extract_top_features`, `gradient_attribution`, `ablation_attribution`,
 `feature_intervention`, `graph_prune`, `concept_direction`, `compute_attribution_graph`) are

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,11 +8,11 @@
 
 **A flexible framework for collaborative AI world model analysis and tuning.**
 
-Interpretune is a (pre-MVP) AI world model analysis framework. It strives to provide composable, shareable latent-space analysis mutually intelligible to humans and agents. By granting a wide range of interpretability
-methods and packages access to composable, shareable analysis operations and state it accelerates novel,
-collaborative, world model analysis and tuning with PyTorch. Both humans and agents can inspect
-and refine the mechanistic and causal faithfulness of model reasoning at mutually intelligible
-levels of abstraction. Core framework goals:
+Interpretune is a (pre-MVP) AI world model analysis framework. It strives to provide composable, shareable latent-space analysis mutually intelligible to humans and agents.
+
+By granting a wide range of interpretability methods and packages access to **composable**, **shareable analysis operations** and **state** it accelerates novel, collaborative, world model analysis and tuning with PyTorch.
+
+Both humans and agents can inspect and refine the mechanistic and causal faithfulness of model reasoning at mutually intelligible levels of abstraction. Core framework goals:
 
 - transparent, causally faithful reasoning
 - augmented model self-reflection


### PR DESCRIPTION
Prose-only change to the docs landing page and the README, which had drifted apart.

- Splits the dense opening paragraph into three, and states the framework goals as a short list.
- Emphasis now falls on the specific terms that carry meaning (composable, shareable analysis operations, state) rather than being spread across whole phrases.
- Settles the SAE-Lens/SAELens spelling on **SAELens**, matching the project's own name and the already-correct `decoderesearch/SAELens` link target.

Two formatting fixes alongside the prose:

- README's adapter-levels list had no blank line before it. GitHub tolerates a list interrupting a paragraph; `index.md` separates both of its lists properly and MyST is stricter, so this keeps the two consistent instead of relying on one renderer being lenient.
- Trailing whitespace stripped from the edited lines.

## CI

Touches only `README.md` and `docs/source/index.md`, so the heavy lanes are excluded by their own path filters (`!docs/**`, `!**/*.md`) — `docs-build` and the Read the Docs preview are the relevant checks. No GPU pipeline run is required.