### PR TITLE
CI: fail the docs build when a notebook artifact is stale

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,6 +23,16 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements/docs.txt
+
+      # Cheap, stdlib-only, and BEFORE the heavy install so it fails fast. The docs render
+      # docs/notebook_artifacts/ in preference to the publish lane (see conf.py), so editing a
+      # notebook without rebuilding its artifact leaves the site showing the OLD text with a
+      # perfectly green build and no error anywhere. This is the only thing that catches that.
+      - name: Check notebook artifacts are not stale
+        run: |
+          python scripts/render_notebook_docs_artifacts.py --check-stale \
+            || { echo "::error::A docs notebook artifact has drifted from its publish source. \
+          Rebuild it with: python scripts/render_notebook_docs_artifacts.py --notebook <name>"; exit 1; }
       - name: Install docs requirements
         run: |
           pip install -r requirements/docs.txt


### PR DESCRIPTION
## Problem

`docs/source/conf.py` stages `docs/notebook_artifacts/` **in preference to** `src/it_examples/notebooks/publish/`, so the published page renders the artifact, not the notebook you edited.

That means editing a notebook without rebuilding its artifact leaves the site showing the **old text** — with a green docs build and no error anywhere.

Not hypothetical: this happened during the scalable-dashboards work. Prose edits appeared lost on the RTD preview while `dev` and `publish` had them all along; only the artifact was stale.

It is the same shape as a suppressed `myst.xref_missing` anchor — wrong output, green build.

## Change

`--check-stale` already existed on `render_notebook_docs_artifacts.py`; nothing ran it. This wires it into `docs-build`, which has **no path filters** and so runs on every push and PR to `main`.

The step is stdlib-only (papermill is imported lazily) and runs **before** the dependency install, so it fails in seconds rather than after a full docs build. On failure it names the drifted artifact and prints the rebuild command.

## Verification

Both directions, not just the happy path:

| Case | Result |
| --- | --- |
| Clean tree | `0 stale artifact(s)` → exit 0 |
| One-line markdown edit injected into a publish notebook | `STALE artifact (rebuild it): …` → exit 1 |

Docs-only workflow change, so no GPU or heavy CI lane is required.