### PR TITLE
Retire the sae-lens fork pin for the released 6.49.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,14 +84,27 @@ examples = [
     "syrupy >= 4.6",  # snapshot testing consumed by the SAEDashboard/SAELens suites run from this env
     # v3 adds the TransformerBridge architecture. 3.5.1 is the release cut from the commit this project
     # previously pinned by git URL (tag v3.5.1 == 4ba2187b), so this is a release-pin of identical code.
-    # Downstreams still cap transformer-lens below 3.x (sae-dashboard `^2.2.0`, sae-lens `>=2.16.1`),
-    # hence the matching entry in [tool.uv] override-dependencies / requirements/ci/overrides.txt.
+    # sae-dashboard caps transformer-lens below 3.x (`^2.2.0`, i.e. <3.0.0), hence the matching entry
+    # in [tool.uv] override-dependencies / requirements/ci/overrides.txt. sae-lens does NOT cap it --
+    # its `>=2.16.1` is a FLOOR, which 3.5.1 satisfies. (Corrected 2026-08-09; the comment previously
+    # listed sae-lens as a capping downstream, which would have made the override look load-bearing
+    # for a constraint that does not exist.)
     "transformer-lens >=3.5.1,<4",
+    # Released floor since 2026-08-09: SAELens#721 merged (`3495640`) and shipped in 6.49.0, so the
+    # Scalable Dashboards fork pin is retired. 6.49.0 is the FIRST release carrying the
+    # `ActivationsStore.get_batch_tokens(move_to_model_device=...)` seam SAEDashboard's columnar
+    # runner uses; SAEDashboard probes for it and degrades gracefully, so this is a floor for the
+    # optimization rather than for correctness.
+    #
+    # NOTE the released alias set is deliberately NARROWER than the fork's: the maintainer verified
+    # every `neuronpedia:` entry against production neuronpedia.org and dropped all 52 gemma-3-1b-it
+    # aliases, which pointed at pages that do not exist. Nothing here depended on them resolving --
+    # they 404'd under the fork too.
+    "sae_lens >= 6.49.0",
     # we comment these out when installing from git urls to avoid dep conflicts
     # note packages that have need to have git url deps override transitive dependencies (e.g. needing to override
     # sae-lens' transformer-lens dependency with a git url dep) need to be moved to git-deps as well
     # "circuit-tracer>=0.1.0",
-    # "sae_lens >= 6.3.1",  # use new sae_lens API
     # "nnsight >= 0.5.15",
 ]
 
@@ -110,11 +123,19 @@ git-deps = [
     # a raw `str` prompt was re-tokenized with add_special_tokens=True, double-prefixing an explicit
     # BOS and silently shifting every position index in the feature-intervention path.
     "circuit-tracer @ git+https://github.com/speediedan/circuit-tracer.git@3fde7e203f3a73da28d24ce2d1f173f92eaf5480",
-    # sae-lens/sae-dashboard: pinned to the validated Scalable Dashboards fork SHAs until the
-    # upstream PRs merge/release (interpretune.utils.neuronpedia_dashboard_pipeline imports
-    # fork-only surface, e.g. sae_dashboard.neuronpedia.prompt_bucketing); flip back to released
-    # version floors at wave-merge time.
-    "sae-lens @ git+https://github.com/speediedan/SAELens.git@86f90b3d3dccd3f6ac729577b979f76f88a525f1",
+    # sae-lens RETIRED from git-deps 2026-08-09 -- SAELens#721 merged and released as 6.49.0, so it
+    # is now a released floor in `dependencies` above. This is the wave's first git-dep to go.
+    #
+    # The retired pin (`speediedan/SAELens@86f90b3d`) must NOT be resurrected: it carries 20 duplicate
+    # YAML keys in `pretrained_saes.yaml` (10 x `path`, 10 x `l0`) from a bad rebase, which silently
+    # bound 10 entries in `gemma-scope-2-1b-pt-` / `-12b-pt-transcoders-all` to the WRONG weights.
+    # Upstream main never had them and the maintainer fixed them before merging. Only `-pt-` releases
+    # were affected and everything here uses `gemma-scope-2-1b-it-transcoders-all`, so nothing we
+    # generated was wrong -- but the pin itself is unsafe.
+    #
+    # sae-dashboard stays pinned: its PR (SD#74) is still open, and
+    # interpretune.utils.neuronpedia_dashboard_pipeline imports fork-only surface
+    # (e.g. sae_dashboard.neuronpedia.prompt_bucketing). Flip it to a released floor at merge.
     # The SD#74 head carrying `columnar_parquet_row_group_size` and `columnar_write_page_index`. Both are hard FLOORS
     # rather than runtime-probed capabilities: interpretune emits --columnar-write-page-index unconditionally, so an
     # older SAEDashboard fails with "unrecognized arguments" rather than silently producing an unindexed
@@ -185,11 +206,12 @@ profiling = [
 # from source we also include this version to ensure it is respected when installing without the
 # --override flag (e.g CI)
 override-dependencies = [
-    # force the v3 line over downstream caps (sae-dashboard pins `^2.2.0`, i.e. <3.0.0; sae-lens
-    # `>=2.16.1`). 3.5.1 is the release of the commit formerly pinned here by git URL (tag v3.5.1 ==
-    # 4ba2187b), so this is the same code with a real version string instead of `0.0.0`.
+    # force the v3 line over sae-dashboard's cap (`^2.2.0`, i.e. <3.0.0). sae-lens' `>=2.16.1` is a
+    # FLOOR, not a cap, and needs no override. 3.5.1 is the release of the commit formerly pinned here
+    # by git URL (tag v3.5.1 == 4ba2187b), so this is the same code with a real version string
+    # instead of `0.0.0`.
     "transformer-lens==3.5.1",
-    # keep transitive nnsight (pulled in by the sae-lens git dep) at the validated release
+    # keep transitive nnsight (pulled in by sae-lens) at the validated release
     # (0.7.0 validated: nnsight slice + parity 34/0 + low-RAM mock, both versions)
     "nnsight==0.7.0",
 ]

--- a/requirements/ci/overrides.txt
+++ b/requirements/ci/overrides.txt
@@ -1,4 +1,4 @@
-transformer-lens==3.5.1  # release of the commit formerly pinned by git URL (tag v3.5.1 == 4ba2187b); overrides sae-dashboard's ^2.2.0 / sae-lens' >=2.16.1 caps
+transformer-lens==3.5.1  # release of the commit formerly pinned by git URL (tag v3.5.1 == 4ba2187b); overrides sae-dashboard's ^2.2.0 cap (sae-lens' >=2.16.1 is a floor, not a cap)
 nnsight==0.7.0  # released pin (0.7.0 validated: sig-key VAR_KEYWORD resolve-through fix + remote-init gating; nnsight slice + parity 34/0 green on 0.6.3 AND 0.7.0)
 # Exactly what torch 2.13.0 requires on Linux. The marker is load-bearing, not decoration: a uv
 # override replaces the target requirement *including its markers*, so an unmarked `triton==3.7.1`

--- a/requirements/ci/requirements.txt
+++ b/requirements/ci/requirements.txt
@@ -14,7 +14,7 @@ aiohttp==3.14.3
     #   papermill
 aiosignal==1.4.0
     # via aiohttp
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via typer
 annotated-types==0.8.0
     # via pydantic
@@ -41,6 +41,8 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
+babe==0.0.7
+    # via sae-lens
 babel==2.18.0
     # via jupyterlab-server
 backports-tarfile==1.2.0 ; python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'
@@ -63,7 +65,7 @@ certifi==2026.7.22
     #   httpx
     #   requests
     #   sentry-sdk
-cffi==2.1.0
+cffi==2.1.1
     # via
     #   argon2-cffi-bindings
     #   cryptography
@@ -75,6 +77,7 @@ charset-normalizer==3.4.9
 click==8.4.2
     # via
     #   huggingface-hub
+    #   nltk
     #   papermill
     #   wandb
 colorama==0.4.6 ; sys_platform == 'win32'
@@ -88,30 +91,35 @@ comm==0.2.3
     # via
     #   ipykernel
     #   ipywidgets
+config2py==0.1.50
+    # via py2store
 contourpy==1.3.2 ; python_full_version < '3.11'
     # via matplotlib
 contourpy==1.3.3 ; python_full_version >= '3.11'
     # via matplotlib
-coverage[toml]==7.15.2
+coverage[toml]==7.15.4
     # via
     #   interpretune (pyproject.toml:test)
     #   nbval
     #   pytest-cov
-cryptography==49.0.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
+cryptography==50.0.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via secretstorage
 cycler==0.12.1
     # via matplotlib
-datasets==5.0.0
+datasets==5.0.1
     # via
     #   interpretune (pyproject.toml)
     #   evaluate
+    #   sae-lens
     #   transformer-lens
 debugpy==1.8.21
     # via ipykernel
-decorator==5.3.1
+decorator==5.3.1 ; python_full_version < '3.11'
     # via ipython
 defusedxml==0.7.1
-    # via nbconvert
+    # via
+    #   nbconvert
+    #   nltk
 dill==0.4.1
     # via
     #   datasets
@@ -120,9 +128,16 @@ dill==0.4.1
 distlib==0.4.3
     # via virtualenv
 docstring-parser==0.18.0
-    # via jsonargparse
+    # via
+    #   jsonargparse
+    #   simple-parsing
 docutils==0.23
     # via readme-renderer
+dol==0.3.58
+    # via
+    #   config2py
+    #   graze
+    #   py2store
 einops==0.8.2
     # via transformer-lens
 entrypoints==0.4
@@ -138,9 +153,9 @@ executing==2.2.1
     # via stack-data
 fancy-einsum==0.0.3
     # via transformer-lens
-fastjsonschema==2.22.0
+fastjsonschema==2.22.1
     # via nbformat
-filelock==3.32.0
+filelock==3.32.2
     # via
     #   datasets
     #   gdown
@@ -158,7 +173,7 @@ frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec[http]==2026.4.0
+fsspec[http]==2026.6.0
     # via
     #   datasets
     #   evaluate
@@ -168,11 +183,13 @@ fsspec[http]==2026.4.0
     #   torch
 gdown==6.1.0
     # via interpretune (pyproject.toml)
+graze==0.1.44
+    # via babe
 grpcio==1.83.0
     # via tensorboard
 h11==0.16.0
     # via httpcore
-hf-xet==1.5.2
+hf-xet==1.6.0
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
@@ -181,7 +198,7 @@ httpx==0.28.1
     #   datasets
     #   huggingface-hub
     #   jupyterlab
-huggingface-hub[hf-xet]==1.24.0
+huggingface-hub[hf-xet]==1.27.0
     # via
     #   interpretune (pyproject.toml:test)
     #   accelerate
@@ -191,6 +208,8 @@ huggingface-hub[hf-xet]==1.24.0
     #   tokenizers
     #   transformer-lens
     #   transformers
+i2==0.1.67
+    # via config2py
 id==1.6.1
     # via twine
 identify==2.6.19
@@ -205,7 +224,7 @@ idna==3.18
 importlib-metadata==9.0.0 ; python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via keyring
 importlib-resources==7.1.0
-    # via typeshed-client
+    # via py2store
 iniconfig==2.3.0
     # via pytest
 ipykernel==7.3.0
@@ -217,7 +236,7 @@ ipython==8.39.0 ; python_full_version < '3.11'
     # via
     #   ipykernel
     #   ipywidgets
-ipython==9.15.0 ; python_full_version >= '3.11'
+ipython==9.16.1 ; python_full_version >= '3.11'
     # via
     #   ipykernel
     #   ipywidgets
@@ -251,7 +270,9 @@ jinja2==3.1.6
     #   nbconvert
     #   torch
 joblib==1.5.3
-    # via scikit-learn
+    # via
+    #   nltk
+    #   scikit-learn
 json5==0.15.0
     # via jupyterlab-server
 jsonargparse[signatures]==4.41.0
@@ -265,7 +286,7 @@ jsonschema[format-nongpl]==4.26.0
     #   nbformat
 jsonschema-specifications==2025.9.1
     # via jsonschema
-jupyter-builder==1.1.1
+jupyter-builder==1.2.2
     # via
     #   jupyterlab
     #   notebook
@@ -325,7 +346,7 @@ lightning-utilities==0.15.3
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.10.2
+markdown==3.10.3
     # via tensorboard
 markdown-it-py==4.2.0
     # via
@@ -374,7 +395,7 @@ nbclient==0.11.0
     #   papermill
 nbconvert==7.17.1
     # via jupyter-server
-nbformat==5.10.4
+nbformat==5.11.0
     # via
     #   jupyter-server
     #   jupytext
@@ -389,10 +410,12 @@ nbval==0.11.0
     # via interpretune (pyproject.toml)
 nest-asyncio2==1.7.2
     # via ipykernel
-neuronpedia==1.2.0
+neuronpedia==1.2.1
     # via interpretune (pyproject.toml)
 nh3==0.3.6
     # via readme-renderer
+nltk==3.10.2
+    # via sae-lens
 nodeenv==1.10.0
     # via
     #   pre-commit
@@ -412,9 +435,12 @@ numpy==2.2.6 ; python_full_version < '3.11'
     #   evaluate
     #   matplotlib
     #   pandas
+    #   patsy
     #   peft
+    #   plotly-express
     #   scikit-learn
     #   scipy
+    #   statsmodels
     #   tensorboard
     #   torchmetrics
     #   transformer-lens
@@ -428,14 +454,17 @@ numpy==2.4.6 ; python_full_version == '3.11.*'
     #   evaluate
     #   matplotlib
     #   pandas
+    #   patsy
     #   peft
+    #   plotly-express
     #   scikit-learn
     #   scipy
+    #   statsmodels
     #   tensorboard
     #   torchmetrics
     #   transformer-lens
     #   transformers
-numpy==2.5.1 ; python_full_version >= '3.12'
+numpy==2.5.2 ; python_full_version >= '3.12'
     # via
     #   accelerate
     #   bitsandbytes
@@ -444,16 +473,19 @@ numpy==2.5.1 ; python_full_version >= '3.12'
     #   evaluate
     #   matplotlib
     #   pandas
+    #   patsy
     #   peft
+    #   plotly-express
     #   scikit-learn
     #   scipy
+    #   statsmodels
     #   tensorboard
     #   torchmetrics
     #   transformer-lens
     #   transformers
 overrides==7.7.0 ; python_full_version < '3.12'
     # via jupyter-server
-packaging==26.2
+packaging==26.3
     # via
     #   accelerate
     #   bitsandbytes
@@ -475,6 +507,7 @@ packaging==26.2
     #   pytest
     #   pytest-rerunfailures
     #   pytorch-lightning
+    #   statsmodels
     #   tensorboard
     #   torchmetrics
     #   transformer-lens
@@ -483,14 +516,20 @@ packaging==26.2
     #   wandb
 pandas==2.3.3 ; python_full_version < '3.11'
     # via
+    #   babe
     #   datasets
     #   evaluate
+    #   plotly-express
+    #   statsmodels
     #   torch-tb-profiler
     #   transformer-lens
 pandas==3.0.5 ; python_full_version >= '3.11'
     # via
+    #   babe
     #   datasets
     #   evaluate
+    #   plotly-express
+    #   statsmodels
     #   torch-tb-profiler
     #   transformer-lens
 pandocfilters==1.5.1
@@ -499,7 +538,11 @@ papermill==2.7.0
     # via interpretune (pyproject.toml:test)
 parso==0.8.7
     # via jedi
-peft==0.19.1
+patsy==1.0.2
+    # via
+    #   plotly-express
+    #   statsmodels
+peft==0.20.0
     # via interpretune (pyproject.toml)
 pexpect==4.9.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
     # via ipython
@@ -509,14 +552,18 @@ pillow==12.3.0
     # via
     #   matplotlib
     #   tensorboard
-platformdirs==4.11.0
+platformdirs==4.11.1
     # via
     #   jupyter-core
-    #   python-discovery
     #   virtualenv
     #   wandb
 plotly==6.9.0
-    # via interpretune (pyproject.toml)
+    # via
+    #   interpretune (pyproject.toml)
+    #   plotly-express
+    #   sae-lens
+plotly-express==0.4.1
+    # via sae-lens
 pluggy==1.6.0
     # via
     #   pytest
@@ -527,7 +574,7 @@ pre-commit==4.6.1
     #   interpretune (pyproject.toml:test)
 prometheus-client==0.26.0
     # via jupyter-server
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -554,6 +601,8 @@ pure-eval==0.2.3
     # via stack-data
 py-spy==0.4.2
     # via interpretune (pyproject.toml:profiling)
+py2store==0.1.22
+    # via babe
 pyarrow==25.0.0
     # via
     #   datasets
@@ -599,12 +648,13 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-discovery==1.5.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via
     #   interpretune (pyproject.toml)
     #   neuronpedia
+    #   sae-lens
 python-json-logger==4.1.0
     # via jupyter-events
 pytorch-lightning==2.6.5
@@ -631,6 +681,7 @@ pyyaml==6.0.3
     #   peft
     #   pre-commit
     #   pytorch-lightning
+    #   sae-lens
     #   transformers
     #   wandb
 pyzmq==27.1.0
@@ -646,12 +697,15 @@ referencing==0.37.0
     #   jsonschema-specifications
     #   jupyter-events
 regex==2026.7.19
-    # via transformers
+    # via
+    #   nltk
+    #   transformers
 requests[socks]==2.34.2
     # via
     #   datasets
     #   evaluate
     #   gdown
+    #   graze
     #   jupyterlab-server
     #   neuronpedia
     #   papermill
@@ -685,21 +739,33 @@ rpds-py==2026.6.3 ; python_full_version >= '3.11'
     # via
     #   jsonschema
     #   referencing
+sae-lens==6.49.0
+    # via interpretune (pyproject.toml)
 safetensors==0.8.0
     # via
     #   accelerate
     #   peft
+    #   sae-lens
     #   transformers
 scikit-learn==1.7.2 ; python_full_version < '3.11'
     # via interpretune (pyproject.toml)
 scikit-learn==1.9.0 ; python_full_version >= '3.11'
     # via interpretune (pyproject.toml)
 scipy==1.15.3 ; python_full_version < '3.11'
-    # via scikit-learn
+    # via
+    #   plotly-express
+    #   scikit-learn
+    #   statsmodels
 scipy==1.17.1 ; python_full_version == '3.11.*'
-    # via scikit-learn
+    # via
+    #   plotly-express
+    #   scikit-learn
+    #   statsmodels
 scipy==1.18.0 ; python_full_version >= '3.12'
-    # via scikit-learn
+    # via
+    #   plotly-express
+    #   scikit-learn
+    #   statsmodels
 secretstorage==3.5.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via keyring
 send2trash==2.1.0
@@ -708,26 +774,32 @@ sentencepiece==0.2.2
     # via transformer-lens
 sentry-sdk==2.66.1
     # via wandb
-setuptools==83.0.0
+setuptools==84.0.0
     # via
     #   tensorboard
     #   torch
 shellingham==1.5.4
     # via typer
+simple-parsing==0.1.9
+    # via sae-lens
 six==1.17.0
     # via
     #   python-dateutil
     #   rfc3339-validator
-soupsieve==2.9.1
+soupsieve==2.9.2
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via plotly-express
 syrupy==5.5.3
     # via interpretune (pyproject.toml)
 tabulate==0.10.0
     # via interpretune (pyproject.toml)
 tenacity==9.1.4
-    # via papermill
+    # via
+    #   papermill
+    #   sae-lens
 tensorboard==2.21.0
     # via torch-tb-profiler
 tensorboard-data-server==0.7.2
@@ -759,7 +831,7 @@ torchmetrics==1.9.0
     # via
     #   lightning
     #   pytorch-lightning
-tornado==6.5.7
+tornado==6.5.8
     # via
     #   ipykernel
     #   jupyter-client
@@ -767,19 +839,20 @@ tornado==6.5.7
     #   jupyterlab
     #   notebook
     #   terminado
-tqdm==4.69.1
+tqdm==4.70.0
     # via
     #   datasets
     #   evaluate
     #   gdown
     #   huggingface-hub
     #   lightning
+    #   nltk
     #   papermill
     #   peft
     #   pytorch-lightning
     #   transformer-lens
     #   transformers
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipykernel
     #   ipython
@@ -798,21 +871,23 @@ transformer-lens==3.5.1
     # via
     #   --override (workspace)
     #   interpretune (pyproject.toml)
+    #   sae-lens
 transformers==5.14.1
     # via
     #   interpretune (pyproject.toml)
     #   peft
+    #   sae-lens
     #   transformer-lens
     #   transformers-stream-generator
 transformers-stream-generator==0.0.5
     # via transformer-lens
-twine==6.2.0
+twine==7.0.0
     # via interpretune (pyproject.toml:test)
-typeguard==4.5.2
+typeguard==4.6.0
     # via transformer-lens
-typer==0.27.0
+typer==0.27.1
     # via transformers
-typeshed-client==2.12.0
+typeshed-client==2.13.0
     # via jsonargparse
 typing-extensions==4.16.0
     # via
@@ -839,6 +914,8 @@ typing-extensions==4.16.0
     #   pyright
     #   pytorch-lightning
     #   referencing
+    #   sae-lens
+    #   simple-parsing
     #   torch
     #   transformer-lens
     #   typeguard
@@ -861,11 +938,11 @@ urllib3==2.7.0
     #   requests
     #   sentry-sdk
     #   twine
-uv==0.11.32
+uv==0.12.3
     # via
     #   interpretune (pyproject.toml:dev)
     #   interpretune (pyproject.toml:test)
-virtualenv==21.7.0
+virtualenv==21.7.3
     # via pre-commit
 wadler-lindig==0.1.7
     # via jaxtyping

--- a/scripts/run_dashboard_benchmark_suite.py
+++ b/scripts/run_dashboard_benchmark_suite.py
@@ -14,6 +14,8 @@ See ``scripts/dashboard_benchmark_suite_usage.md`` for example commands.
 from __future__ import annotations
 
 import argparse
+import importlib.metadata as md
+import importlib.util
 import json
 import os
 import shutil
@@ -237,12 +239,50 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+#: Benchmark-relevant packages that MAY be installed from a release rather than a source checkout.
+#: Mapped abbr -> distribution name so lineage can name the release instead of an unrelated checkout.
+LINEAGE_DISTRIBUTIONS = {"SD": "sae-dashboard", "SL": "sae-lens"}
+
+
+def _released_provenance(abbr: str, root: Path) -> str | None:
+    """``v<version>`` when the INSTALLED package is a release rather than this checkout, else None.
+
+    A source checkout sitting on disk does not mean the run used it. Once a package moves from a git
+    pin to a released floor (sae-lens did, 2026-08-09), the checkout usually stays behind — so
+    stamping its HEAD attributes the run to code that was never imported. That is worse than an
+    unknown: after the sae-lens repin the stale checkout still read ``86f90b3d``, the very commit
+    retired for carrying corrupt ``pretrained_saes.yaml`` entries, so every manifest would have
+    blamed a run on it.
+
+    Resolves the import location instead: if the package does not live under ``root``, the checkout
+    is irrelevant and the release version is the honest provenance.
+    """
+    dist = LINEAGE_DISTRIBUTIONS.get(abbr)
+    if dist is None:
+        return None
+    try:
+        spec = importlib.util.find_spec(dist.replace("-", "_"))
+        if spec is None or not spec.origin:
+            return None
+        if root.resolve() in Path(spec.origin).resolve().parents:
+            return None  # editable/source install backed by this checkout -- the git sha is correct
+        return f"v{md.version(dist)}"
+    except Exception:  # provenance must never be the thing that fails a benchmark run
+        return None
+
+
 def capture_lineage(repo_roots: dict[str, Path]) -> tuple[dict[str, str], list[str]]:
-    """Return {abbr: short_sha} plus the list of dirty repo abbreviations."""
+    """Return {abbr: short_sha or v<release>} plus the list of dirty repo abbreviations.
+
+    A released package contributes no dirty state -- there is no working tree to be dirty.
+    """
 
     shas: dict[str, str] = {}
     dirty: list[str] = []
     for abbr, root in repo_roots.items():
+        if (released := _released_provenance(abbr, root)) is not None:
+            shas[abbr] = released
+            continue
         try:
             sha = subprocess.run(
                 ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],

--- a/src/interpretune/utils/import_utils.py
+++ b/src/interpretune/utils/import_utils.py
@@ -5,7 +5,7 @@ from importlib.util import find_spec
 from importlib.metadata import version as get_version, PackageNotFoundError
 import operator
 import torch
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 from interpretune.utils import MisconfigurationException
 
@@ -155,8 +155,11 @@ def compare_version(package: str, op: Callable, version_str: str, use_base_versi
         else:
             # try importlib.metadata to infer version
             pkg_version = Version(get_version(package))
-    except (TypeError, PackageNotFoundError):
-        # this is mocked by Sphinx, so it should return True to generate all summaries
+    except (TypeError, InvalidVersion, PackageNotFoundError):
+        # `__version__` is not a parseable version -- Sphinx mocks it, so return True and let all
+        # summaries generate. BOTH exception types are required: packaging <= 26.2 let the underlying
+        # TypeError escape, while 26.3+ catches it and re-raises `InvalidVersion` (a ValueError).
+        # Catching only TypeError makes this raise on 26.3+, which is how CI caught it.
         return True
     if use_base_version:
         pkg_version = Version(pkg_version.base_version)

--- a/src/it_examples/patching/_patch_utils.py
+++ b/src/it_examples/patching/_patch_utils.py
@@ -2,7 +2,7 @@ import operator
 import sys
 from typing import Callable
 import importlib.metadata
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from functools import lru_cache
 
 
@@ -14,8 +14,9 @@ def lwt_compare_version(
         pkg_version = Version(importlib.metadata.version(package))
     except importlib.metadata.PackageNotFoundError:
         return False
-    except TypeError:
-        # possibly mocked by Sphinx so needs to return True to generate summaries
+    except (TypeError, InvalidVersion):
+        # possibly mocked by Sphinx so needs to return True to generate summaries. Both types are
+        # needed: packaging <= 26.2 let the TypeError escape, 26.3+ re-raises it as InvalidVersion.
         return True
     if local_version:
         if not operator.eq(local_version, pkg_version.local):

--- a/tests/core/test_dashboard_benchmark_artifacts.py
+++ b/tests/core/test_dashboard_benchmark_artifacts.py
@@ -4,7 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -395,3 +395,56 @@ class TestRendering:
         payload = json.loads(out.read_text(encoding="utf-8"))
         assert len(payload["variants"]) == 2
         assert payload["summary_stages"] == list(dba.SUMMARY_STAGES)
+
+
+class TestLineageProvenance:
+    """A released dependency must be stamped as its RELEASE, never as a stale checkout's HEAD.
+
+    Regression guard for the sae-lens repin (2026-08-09). `speediedan/SAELens` stayed on disk after
+    the package moved to a released floor, so `capture_lineage` would have stamped `SL-86f90b3d` --
+    the commit retired for carrying corrupt `pretrained_saes.yaml` entries -- onto runs that actually
+    imported sae-lens 6.49.0 from PyPI. A manifest that names code the run never loaded is worse than
+    one that says nothing.
+    """
+
+    def test_release_install_is_stamped_as_the_release(self, tmp_path: Path, monkeypatch):
+        """Package resolved OUTSIDE the checkout -> the checkout is irrelevant."""
+        pkg = tmp_path / "site-packages" / "sae_lens" / "__init__.py"
+        pkg.parent.mkdir(parents=True)
+        pkg.write_text("", encoding="utf-8")
+        monkeypatch.setattr(suite.importlib.util, "find_spec", lambda _n: SimpleNamespace(origin=str(pkg)))
+        monkeypatch.setattr(suite.md, "version", lambda _d: "6.49.0")
+
+        assert suite._released_provenance("SL", tmp_path / "repos" / "SAELens") == "v6.49.0"
+
+    def test_source_install_keeps_the_git_sha(self, tmp_path: Path, monkeypatch):
+        """Package resolved INSIDE the checkout -> the git sha is the honest answer."""
+        root = tmp_path / "repos" / "SAELens"
+        pkg = root / "sae_lens" / "__init__.py"
+        pkg.parent.mkdir(parents=True)
+        pkg.write_text("", encoding="utf-8")
+        monkeypatch.setattr(suite.importlib.util, "find_spec", lambda _n: SimpleNamespace(origin=str(pkg)))
+
+        assert suite._released_provenance("SL", root) is None
+
+    def test_untracked_abbrs_are_never_release_stamped(self, tmp_path: Path):
+        """IT and NP are always source checkouts; they must keep using git."""
+        assert suite._released_provenance("IT", tmp_path) is None
+        assert suite._released_provenance("NP", tmp_path) is None
+
+    def test_provenance_never_raises(self, tmp_path: Path, monkeypatch):
+        """Provenance is metadata; it must not be able to fail a benchmark run."""
+
+        def _boom(_n):
+            raise RuntimeError("resolver exploded")
+
+        monkeypatch.setattr(suite.importlib.util, "find_spec", _boom)
+        assert suite._released_provenance("SL", tmp_path) is None
+
+    def test_released_dep_contributes_no_dirty_state(self, tmp_path: Path, monkeypatch):
+        """There is no working tree to be dirty, so a release must not appear in `dirty`."""
+        monkeypatch.setattr(suite, "_released_provenance", lambda abbr, _root: "v6.49.0" if abbr == "SL" else None)
+        shas, dirty = suite.capture_lineage({"SL": tmp_path / "nonexistent"})
+
+        assert shas == {"SL": "v6.49.0"}
+        assert dirty == []

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -21,6 +21,7 @@ import tempfile
 
 import pytest
 import torch
+from packaging.version import InvalidVersion
 
 from tests.runif import RunIf
 from tests.utils import ablate_cls_attrs
@@ -147,6 +148,18 @@ class TestClassUtils:
         with ablate_cls_attrs(torch, "__version__"):
             assert compare_version("torch", operator.ge, "2.0.0", use_base_version=True)
         with patch.object(torch, "__version__", lambda x: x + 1):  # allow TypeError for Sphinx mocks
+            assert compare_version("torch", operator.ge, "2.0.0", use_base_version=True)
+
+    @pytest.mark.parametrize("raised", [TypeError("not a version"), InvalidVersion("not a version")])
+    def test_compare_version_tolerates_either_unparseable_version_error(self, raised):
+        """An unparseable ``__version__`` must degrade to True whichever error packaging raises.
+
+        The live test above only exercises whichever one the INSTALLED packaging happens to raise, so
+        it silently covers one branch per environment. packaging <= 26.2 let the underlying TypeError
+        escape; 26.3 catches it and re-raises ``InvalidVersion``. CI moved to 26.3 via a lock
+        regeneration and the previously-passing test failed, which is the gap this closes.
+        """
+        with patch("interpretune.utils.import_utils.Version", side_effect=raised):
             assert compare_version("torch", operator.ge, "2.0.0", use_base_version=True)
 
     @RunIf(min_cuda_gpus=1)


### PR DESCRIPTION
SAELens#721 merged 2026-08-09 (`3495640`) and shipped in **6.49.0**, so the Scalable Dashboards fork
pin is no longer needed. First of the wave's three git-deps to go.

## Why the retired pin should not come back

`speediedan/SAELens@86f90b3d` carries **20 duplicate YAML keys** in `pretrained_saes.yaml`
(10 × `path`, 10 × `l0`) from a bad rebase, silently binding 10 entries in
`gemma-scope-2-1b-pt-` / `-12b-pt-transcoders-all` to the **wrong weights**. Upstream `main` never had
them; the maintainer repaired them before merging.

Only `-pt-` releases were affected, and everything here uses `gemma-scope-2-1b-it-transcoders-all`, so
**nothing generated or published was wrong** — but the pin itself is unsafe, and the comment now says so.

## The move is output-neutral

| check | result |
| --- | --- |
| sae ids (`gemma-scope-2-1b-it-transcoders-all`) | 208 both, same set |
| **weights paths** | **identical** |
| `l0` / `repo_id` / `model` / `conversion_func` | identical |
| `neuronpedia:` ids | 52 differ, all → `null` |

The 52 link ids are the only delta. Generation never reads them — the sole consumer is
`display_dashboard`, a notebook helper — and they were already broken, pointing at production pages
that do not exist, which is why the maintainer removed them.

Empirically confirmed: **SAEDashboard's byte-level golden parity acceptance suite passes against the
released package** (283 passed).

## Benchmark lineage had to change with it

`capture_lineage` ran `git rev-parse` in the SAELens checkout, which is no longer what gets imported.
It would have stamped **`SL-86f90b3d`** — the commit just retired for corruption — onto runs that
actually used 6.49.0 from PyPI. A manifest naming code the run never loaded is worse than one that
says nothing.

`_released_provenance` now resolves the import location and records `SL-v6.49.0` when the package is a
release, keeping the git sha when a checkout genuinely backs it (SD still does). Five regression tests,
including that a release contributes no dirty state and that provenance can never fail a run.

## CI lock

`sae-lens` is now in `requirements/ci/requirements.txt` (it was excluded while a git-dep), which also
pulls in its transitive deps: `babe`, `config2py`, `dol`, `graze`, `i2`, `nltk`, `patsy`,
`plotly-express`, `py2store`, `simple-parsing`, `statsmodels`. The remaining lock churn is ordinary
drift since it was last regenerated (`cryptography`, `peft`, `datasets`, `setuptools` et al), **not** a
consequence of this change — flagging it since it rides along.

## Also

Corrects a comment naming sae-lens as capping transformer-lens below 3.x. It does not — `>=2.16.1` is
a **floor**. Only sae-dashboard's `^2.2.0` caps, so only it needs the uv override.

## Local verification

- interpretune full suite: **1481 passed / 118 skipped**
- SAEDashboard unit + golden parity acceptance: **283 passed**
- SAELens-adjacent targeted: **181 passed**
- benchmark-artifact module (incl. 5 new): **35 passed**