### PR TITLE
Docs URLs: interpretune.org canonical; fix broken /en/stable/ Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Composable, shareable latent-space analysis mutually intelligible to humans and agents.*
 
 [![CI](https://github.com/speediedan/interpretune/actions/workflows/ci_test-full.yml/badge.svg)](https://github.com/speediedan/interpretune/actions/workflows/ci_test-full.yml)
-[![Docs](https://readthedocs.org/projects/interpretune/badge/?version=latest)](https://interpretune.readthedocs.io/en/latest/)
+[![Docs](https://readthedocs.org/projects/interpretune/badge/?version=latest)](https://interpretune.org/en/latest/)
 [![codecov](https://codecov.io/gh/speediedan/interpretune/branch/main/graph/badge.svg)](https://codecov.io/gh/speediedan/interpretune)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://github.com/speediedan/interpretune/blob/main/pyproject.toml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green)](./LICENSE)
@@ -62,7 +62,7 @@ is planned.
 | **Extensions** | Cross-cutting capabilities: memory profiling, debug generation, Neuronpedia dashboard/explanation integration. |
 
 A minimal flavor of the composition pattern (see the
-[docs](https://interpretune.readthedocs.io/en/latest/) and `src/it_examples/notebooks/` demos for
+[docs](https://interpretune.org/en/latest/) and `src/it_examples/notebooks/` demos for
 runnable versions):
 
 ```python
@@ -157,11 +157,11 @@ Jacobian-space (J-lens) analysis support
 reflection heuristics for more sample-efficient RL exploration), epistemic-coherence objectives,
 reflective cognition for counterfactuals via latent-state evaluation, meta-latent world-model
 interfaces, and multimodal world-model support — see the
-[roadmap docs](https://interpretune.readthedocs.io/en/latest/roadmap.html).
+[roadmap docs](https://interpretune.org/en/latest/roadmap.html).
 
 ## Documentation
 
-- [Latest docs](https://interpretune.readthedocs.io/en/latest/) — concepts, usage guides, design
+- [Latest docs](https://interpretune.org/en/latest/) — concepts, usage guides, design
   notes, API reference
 - Demo notebooks: `src/it_examples/notebooks/` (circuit-tracer analysis + concept-steering demos,
   SAE-Lens and NNsight adapter examples, with Colab badges on published copies)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 [project.urls]
 "Homepage" = "https://github.com/speediedan/interpretune"
 "Bug Tracker" = "https://github.com/speediedan/interpretune/issues"
-"Documentation" = "https://interpretune.readthedocs.io/en/stable/"
+"Documentation" = "https://interpretune.org/en/latest/"
 "Source Code" = "https://github.com/speediedan/interpretune"
 
 [project.entry-points."console_scripts"]


### PR DESCRIPTION
Repoints the README docs links (×4) and `pyproject.toml`'s `Documentation` project URL to the new canonical docs domain **interpretune.org** (RTD-served; `interpretune.readthedocs.io` already 302s to canonical, so existing links keep working).

The `Documentation` URL additionally changes `/en/stable/` → `/en/latest/`: no `stable` version exists on this RTD project, so the advertised URL was broken today independent of the domain change (it would have shipped to PyPI at the alpha).

Deliberately untouched: the RTD status badge **image** (readthedocs.org project badge — still correct), third-party `coverage.readthedocs.io`, and `docs/benchmark_artifacts/**` (isolated surface for the open dashboards-wave PRs; its URL follows via that workstream later).

Domain verification (certs at apex/www, one-hop .com redirect with path+query preservation, canonical redirect live) per the domains workstream hand-off, 2026-08-11.

https://claude.ai/code/session_01LLCoZFeosQ8BcGmMRNGu5m