### PR TITLE
Fix infinite recursion resolving it.hub in a fresh process

### DIFF
--- a/src/interpretune/__init__.py
+++ b/src/interpretune/__init__.py
@@ -148,10 +148,18 @@ def __getattr__(name: str):
     This uses PEP 562 (__getattr__ on packages).
     """
     if name in _LAZY_MODULE_ATTRS:
+        import importlib
+
         module_path = _LAZY_MODULE_ATTRS[name]
         module_name, attr = module_path.rsplit(".", 1)
-        module = __import__(module_name, fromlist=[attr])
-        val = getattr(module, attr)
+        if module_name == __name__ and attr == name:
+            # the attr IS a direct submodule (e.g. `it.hub`): import it directly. Importing the
+            # PARENT with fromlist would re-enter this __getattr__ for the same name — infinite
+            # recursion in any process that has not already imported the submodule some other way.
+            val = importlib.import_module(module_path)
+        else:
+            module = importlib.import_module(module_name)
+            val = getattr(module, attr)
         globals()[name] = val
         return val
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/tests/core/test_adapters_import_time.py
+++ b/tests/core/test_adapters_import_time.py
@@ -74,3 +74,24 @@ def test_import_interpretune_does_not_pull_adapters_and_is_fast():
         f"interpretune median import time across {attempts} subprocesses took too long "
         f"({duration:.2f}s) — expected < {threshold:.1f}s on {system}; raw timings={durations}"
     )
+
+
+def test_it_hub_resolves_in_fresh_process():
+    """`it.hub` must resolve in a process that never imported interpretune.hub another way.
+
+    Regression pin for the lazy-submodule recursion: resolving a direct-submodule attr by importing
+    the PARENT with a fromlist re-enters the package __getattr__ for the same name — infinite
+    recursion. Every in-repo consumer imported interpretune.hub.* directly first, which masked it;
+    the first clean-process `it.hub.push(...)` (the seed publish) hit it. Subprocess-only by
+    necessity: an in-process assertion could pass spuriously for exactly the masking reason.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import interpretune as it; assert it.hub.__name__ == 'interpretune.hub'"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]


### PR DESCRIPTION
Direct-submodule lazy attrs (the `hub` entry added in #246) resolved by importing the parent package with a fromlist; `_handle_fromlist` then getattr's the parent for the same name, re-entering the package `__getattr__` — infinite recursion in any process that has not already imported `interpretune.hub` some other way.

Every in-repo consumer (tests, notebooks via `ensure_local_seeds`) imports `interpretune.hub.*` directly first, which masked it; the first clean-process `it.hub.push(...)` call (the seed-repo publish, moments after #247 merged) hit it.

Direct-submodule attrs now `import_module` the submodule itself. The regression test runs in a fresh subprocess **by necessity** — an in-process assertion could pass spuriously for exactly the masking reason.

Found during the publish gate: both seed repos were published successfully via the direct `publish_component` import while this fix was prepared.

https://claude.ai/code/session_012imiEjRoeXbsnUk3qzNWDg