### PR TITLE
regen-ci-req: monthly cadence, and stop commenting on the regen PR itself

### DIFF
--- a/.github/workflows/regen-ci-req-check.yml
+++ b/.github/workflows/regen-ci-req-check.yml
@@ -3,7 +3,11 @@ name: regen-ci-req-check (scheduled)
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 1,15 * *'  # run 00:00 UTC on 1st and 15th of each month
+    # 00:00 UTC on the 1st. MONTHLY, deliberately: the pins this refreshes are CI-only, every run
+    # that finds drift costs a full matrix review, and a fortnightly cadence produced a standing
+    # open PR that was continuously force-pushed rather than reviewed. `workflow_dispatch` covers
+    # the case where a refresh is wanted sooner.
+    - cron: '0 0 1 * *'
 
 jobs:
   regen:

--- a/.github/workflows/regen-ci-req-report.yml
+++ b/.github/workflows/regen-ci-req-report.yml
@@ -78,7 +78,11 @@ jobs:
 
 
       - name: Create or update PR comment (single-comment)
-        if: ${{ github.event_name == 'pull_request' }}
+        # Never comment on the regen automation's own PR. Regenerating on a branch that exists
+        # BECAUSE it was just regenerated finds nothing by construction, so the comment there is a
+        # tautology that reads like a verdict on the PR's contents ("no pin changes detected" on a
+        # PR whose entire diff is pin changes) — it wasted a maintainer's time exactly once.
+        if: ${{ github.event_name == 'pull_request' && github.head_ref != 'regen/pinned-requirements' }}
         uses: actions/github-script@v7
         env:
           CHANGED: ${{ steps.regen_ci_reqs.outputs.changed }}
@@ -101,7 +105,10 @@ jobs:
             if (changed === 'true') {
               bodyText = `${marker}\n**regen-ci-req-check** detected changes to pinned CI requirements and uploaded a patch artifact named 'regen-pins-diff'.\n\n${summary ? summary + '\n\n' : ''}Please review the artifact and CI results. This workflow is report-only and will not open a PR; the scheduled regen workflow will open PRs automatically.`;
             } else {
-              bodyText = `${marker}\nNo CI pin file changes detected by regen-ci-req-check.`;
+              // Say what was actually checked. The old wording ("No CI pin file changes detected by
+              // regen-ci-req-check") named the OTHER workflow and read as a claim about this PR's
+              // diff, rather than the regeneration this job just ran against this branch.
+              bodyText = `${marker}\nRegenerating the CI pins on this branch produces no changes — the committed pins are current.`;
             }
             const pr = context.payload.pull_request && context.payload.pull_request.number;
             const headFullName = context.payload.pull_request && context.payload.pull_request.head && context.payload.pull_request.head.repo && context.payload.pull_request.head.repo.full_name;


### PR DESCRIPTION
Two fixes to the pinned-requirements automation, prompted by the confusion around #263.

## What was actually wrong

**Not** what it looked like. #263 is a legitimate PR: its diff is real upstream version bumps
(bitsandbytes 0.50.0→0.50.1, charset-normalizer 3.4.9→3.5.0, dol, filelock, jupyterlab, nltk, …),
and its hosted CI is fully green.

The `No CI pin file changes detected by regen-ci-req-check` line on that PR came from the
**report-only** workflow commenting on the regen branch. Regenerating on a branch that exists
*because* it was just regenerated finds nothing by construction, so the comment was a tautology —
but it named the other workflow and read as a verdict on the PR's contents, i.e. "this PR has no pin
changes" on a PR whose entire diff is pin changes.

## Changes

- **Monthly cadence** (`0 0 1 * *`, was the 1st and 15th). Every run that finds drift costs a full
  matrix review of CI-only pins, and since the PR branch is deliberately stable, the fortnightly
  cadence produced a standing PR that got force-pushed rather than reviewed. `workflow_dispatch`
  still covers an on-demand refresh.
- **No comment on `regen/pinned-requirements`**, and the no-drift wording elsewhere now states what
  was checked ("regenerating the CI pins on this branch produces no changes") instead of naming the
  scheduled workflow.

## On "avoid generating a PR with no pin changes"

That guard already exists and works: the scheduled job gates PR creation on `changed == 'true'`,
`git diff` after a regeneration can only report the two files the lock script writes, and both are
in the `create-pull-request` `add-paths` (and `create-pull-request` does not open a PR when there is
nothing to commit).

Verified empirically rather than assumed — re-running `lock_ci_requirements.sh` on #263's branch
produced **only four further version bumps** (charset-normalizer, fastjsonschema,
python-json-logger, +1 — all released in the ~17 hours since that PR was cut) with **no header or
trailing-newline churn**. That is the reproducibility #229 asked for, so its two causes are
confirmed fixed in `lock_ci_requirements.sh`, and all remaining drift is genuine upstream movement.

It also shows why fortnightly was the wrong cadence: these pins move daily, so the schedule is
choosing a review interval, not catching a rare event.